### PR TITLE
Add core uncertainty calculation module for TPX1 detector

### DIFF
--- a/src/ibeatles/core/detector/__init__.py
+++ b/src/ibeatles/core/detector/__init__.py
@@ -9,6 +9,7 @@ from ibeatles.core.detector.uncertainty import (
     OccupancyWarning,
     ZeroCountMethod,
     aggregate_roi_uncertainty,
+    calculate_relative_uncertainty,
     calculate_transmission_std,
     calculate_transmission_variance,
     check_occupancy_validity,
@@ -17,10 +18,11 @@ from ibeatles.core.detector.uncertainty import (
 
 __all__ = [
     "OccupancyWarning",
-    "calculate_transmission_variance",
-    "calculate_transmission_std",
-    "check_occupancy_validity",
-    "aggregate_roi_uncertainty",
-    "handle_zero_counts",
     "ZeroCountMethod",
+    "aggregate_roi_uncertainty",
+    "calculate_relative_uncertainty",
+    "calculate_transmission_std",
+    "calculate_transmission_variance",
+    "check_occupancy_validity",
+    "handle_zero_counts",
 ]

--- a/src/ibeatles/core/detector/__init__.py
+++ b/src/ibeatles/core/detector/__init__.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+"""Detector-specific modules for neutron imaging data processing.
+
+This package contains modules for TPX1 MCP detector corrections and
+uncertainty calculations.
+"""
+
+from ibeatles.core.detector.uncertainty import (
+    OccupancyWarning,
+    ZeroCountMethod,
+    aggregate_roi_uncertainty,
+    calculate_transmission_std,
+    calculate_transmission_variance,
+    check_occupancy_validity,
+    handle_zero_counts,
+)
+
+__all__ = [
+    "OccupancyWarning",
+    "calculate_transmission_variance",
+    "calculate_transmission_std",
+    "check_occupancy_validity",
+    "aggregate_roi_uncertainty",
+    "handle_zero_counts",
+    "ZeroCountMethod",
+]

--- a/src/ibeatles/core/detector/uncertainty.py
+++ b/src/ibeatles/core/detector/uncertainty.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python
+"""Uncertainty calculations for TPX1 MCP detector corrected transmission data.
+
+This module implements uncertainty propagation for the TPX1 detector efficiency
+correction algorithm. The correction formula is:
+
+    T_i = F_i / ((1 - P_i) * s_i)
+
+where:
+    - T_i: corrected transmission for frame i
+    - F_i: raw frame counts (Poisson-distributed)
+    - P_i: cumulative pixel occupancy probability at frame i
+    - s_i: shutter normalization ratio (shutter_counts[i] / shutter_counts[0])
+
+The variance formula, derived via error propagation assuming Poisson statistics
+for raw counts, is:
+
+    Var(T_i) = T_i / ((1 - P_i) * s_i)
+
+This formula was validated via Monte Carlo simulation in the uncertainty
+validation notebook (see notebooks/uncertainty_validation.ipynb).
+
+References
+----------
+- TPX1 MCP detector correction algorithm from NeutronImagingScripts
+- Validation notebook: notebooks/uncertainty_validation.ipynb
+"""
+
+import logging
+import warnings
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Tuple, Union
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class ZeroCountMethod(Enum):
+    """Methods for handling zero counts in uncertainty calculation.
+
+    Attributes
+    ----------
+    NONE : str
+        No special handling; zero counts yield zero variance.
+    ANSCOMBE : str
+        Apply Anscombe transform: T + 0.375 to stabilize variance.
+        Recommended for variance-stabilizing transformation.
+    SMALL_CONSTANT : str
+        Add small constant (0.5) to transmission before calculation.
+        Simple approach but may introduce bias.
+    MINIMUM_COUNT : str
+        Treat zero as minimum detectable (1 count equivalent).
+        Conservative approach that prevents zero variance.
+    """
+
+    NONE = "none"
+    ANSCOMBE = "anscombe"
+    SMALL_CONSTANT = "small_constant"
+    MINIMUM_COUNT = "minimum_count"
+
+
+@dataclass
+class OccupancyWarning:
+    """Warning information about occupancy levels.
+
+    Attributes
+    ----------
+    level : str
+        Warning level: "safe", "caution", "warning", or "critical".
+    max_occupancy : float
+        Maximum occupancy value found in the data.
+    affected_fraction : float
+        Fraction of pixels/frames affected by high occupancy.
+    message : str
+        Human-readable warning message.
+    """
+
+    level: str
+    max_occupancy: float
+    affected_fraction: float
+    message: str
+
+
+# Occupancy thresholds based on validation analysis
+OCCUPANCY_THRESHOLD_SAFE = 0.50  # <50%: safe region
+OCCUPANCY_THRESHOLD_CAUTION = 0.70  # 50-70%: caution region
+OCCUPANCY_THRESHOLD_WARNING = 0.90  # 70-90%: warning region
+# >90%: critical region (first-order approximation breaks down)
+
+
+def calculate_transmission_variance(
+    transmission: np.ndarray,
+    occupancy: np.ndarray,
+    shutter_n_ratio: Union[np.ndarray, float],
+    zero_count_method: ZeroCountMethod = ZeroCountMethod.NONE,
+) -> np.ndarray:
+    """Calculate variance of corrected transmission values.
+
+    Implements the variance formula derived from error propagation:
+
+        Var(T_i) = T_i / ((1 - P_i) * s_i)
+
+    This formula assumes:
+    - Raw counts follow Poisson distribution
+    - Occupancy P_i is treated as known (not a random variable)
+    - Shutter ratio s_i is treated as known (not a random variable)
+
+    Parameters
+    ----------
+    transmission : np.ndarray
+        Corrected transmission values T_i. Shape can be (n_frames,),
+        (n_frames, height, width), or (height, width) for single frame.
+    occupancy : np.ndarray
+        Cumulative pixel occupancy probability P_i. Must be broadcastable
+        to transmission shape.
+    shutter_n_ratio : np.ndarray or float
+        Shutter normalization ratio s_i = shutter_counts / shutter_counts[0].
+        Must be broadcastable to transmission shape. For per-frame values,
+        use shape (n_frames,) or (n_frames, 1, 1).
+    zero_count_method : ZeroCountMethod, optional
+        Method for handling zero/near-zero transmission values.
+        Default is ZeroCountMethod.NONE.
+
+    Returns
+    -------
+    np.ndarray
+        Variance of transmission values, same shape as input transmission.
+
+    Raises
+    ------
+    ValueError
+        If occupancy values are >= 1.0 (would cause division by zero).
+        If shutter_n_ratio contains non-positive values.
+
+    Notes
+    -----
+    The variance formula is exact under the assumption that occupancy
+    is deterministic. In practice, occupancy has its own uncertainty,
+    but this contribution is typically small compared to counting
+    statistics for occupancy < 0.7.
+
+    Examples
+    --------
+    >>> transmission = np.array([100.0, 150.0, 200.0])
+    >>> occupancy = np.array([0.1, 0.2, 0.3])
+    >>> shutter_n_ratio = 1.0
+    >>> var = calculate_transmission_variance(transmission, occupancy, shutter_n_ratio)
+    >>> np.allclose(var, transmission / ((1 - occupancy) * shutter_n_ratio))
+    True
+    """
+    transmission = np.asarray(transmission, dtype=np.float64)
+    occupancy = np.asarray(occupancy, dtype=np.float64)
+    shutter_n_ratio = np.asarray(shutter_n_ratio, dtype=np.float64)
+
+    # Validate inputs
+    if np.any(occupancy >= 1.0):
+        raise ValueError(
+            f"Occupancy values must be < 1.0 to avoid division by zero. Max occupancy: {np.max(occupancy):.4f}"
+        )
+
+    if np.any(shutter_n_ratio <= 0):
+        raise ValueError(f"Shutter ratio must be positive. Min ratio: {np.min(shutter_n_ratio):.4f}")
+
+    # Apply zero count handling
+    T_effective = handle_zero_counts(transmission, occupancy, shutter_n_ratio, zero_count_method)
+
+    # Calculate variance: Var(T) = T / ((1 - P) * s)
+    denominator = (1.0 - occupancy) * shutter_n_ratio
+    variance = T_effective / denominator
+
+    # Ensure non-negative variance (handle numerical edge cases)
+    variance = np.maximum(variance, 0.0)
+
+    return variance
+
+
+def calculate_transmission_std(
+    transmission: np.ndarray,
+    occupancy: np.ndarray,
+    shutter_n_ratio: Union[np.ndarray, float],
+    zero_count_method: ZeroCountMethod = ZeroCountMethod.NONE,
+) -> np.ndarray:
+    """Calculate standard deviation of corrected transmission values.
+
+    This is a convenience function that returns sqrt(variance).
+
+    Parameters
+    ----------
+    transmission : np.ndarray
+        Corrected transmission values T_i.
+    occupancy : np.ndarray
+        Cumulative pixel occupancy probability P_i.
+    shutter_n_ratio : np.ndarray or float
+        Shutter normalization ratio s_i.
+    zero_count_method : ZeroCountMethod, optional
+        Method for handling zero/near-zero transmission values.
+
+    Returns
+    -------
+    np.ndarray
+        Standard deviation of transmission values.
+
+    See Also
+    --------
+    calculate_transmission_variance : Returns variance instead of std.
+    """
+    variance = calculate_transmission_variance(transmission, occupancy, shutter_n_ratio, zero_count_method)
+    return np.sqrt(variance)
+
+
+def handle_zero_counts(
+    transmission: np.ndarray,
+    occupancy: np.ndarray,
+    shutter_n_ratio: Union[np.ndarray, float],
+    method: ZeroCountMethod,
+) -> np.ndarray:
+    """Apply zero-count handling to transmission values for variance calculation.
+
+    Parameters
+    ----------
+    transmission : np.ndarray
+        Corrected transmission values.
+    occupancy : np.ndarray
+        Cumulative pixel occupancy probability.
+    shutter_n_ratio : np.ndarray or float
+        Shutter normalization ratio.
+    method : ZeroCountMethod
+        Method to use for handling zero counts.
+
+    Returns
+    -------
+    np.ndarray
+        Modified transmission values suitable for variance calculation.
+
+    Notes
+    -----
+    Different methods have different trade-offs:
+
+    - NONE: Preserves zeros but gives zero variance (may underestimate uncertainty)
+    - ANSCOMBE: Variance-stabilizing, good statistical properties
+    - SMALL_CONSTANT: Simple but may introduce bias
+    - MINIMUM_COUNT: Conservative, ensures non-zero variance
+    """
+    transmission = np.asarray(transmission, dtype=np.float64)
+    T_effective = transmission.copy()
+
+    if method == ZeroCountMethod.NONE:
+        return T_effective
+
+    elif method == ZeroCountMethod.ANSCOMBE:
+        # Anscombe transform: add 3/8 to stabilize variance
+        # This is applied to the effective transmission for variance calculation
+        T_effective = transmission + 0.375
+        return T_effective
+
+    elif method == ZeroCountMethod.SMALL_CONSTANT:
+        # Add 0.5 to zero values only
+        zero_mask = transmission <= 0
+        T_effective[zero_mask] = 0.5
+        return T_effective
+
+    elif method == ZeroCountMethod.MINIMUM_COUNT:
+        # Treat zeros as 1-count equivalent
+        # T_min = 1 / ((1 - P) * s) is the minimum detectable transmission
+        shutter_n_ratio = np.asarray(shutter_n_ratio, dtype=np.float64)
+        T_min = 1.0 / ((1.0 - occupancy) * shutter_n_ratio)
+        zero_mask = transmission <= 0
+        T_effective[zero_mask] = T_min[zero_mask] if hasattr(T_min, "__getitem__") else T_min
+        return T_effective
+
+    else:
+        raise ValueError(f"Unknown zero count method: {method}")
+
+
+def check_occupancy_validity(
+    occupancy: np.ndarray,
+    threshold_safe: float = OCCUPANCY_THRESHOLD_SAFE,
+    threshold_caution: float = OCCUPANCY_THRESHOLD_CAUTION,
+    threshold_warning: float = OCCUPANCY_THRESHOLD_WARNING,
+) -> OccupancyWarning:
+    """Check occupancy levels and return appropriate warning.
+
+    The uncertainty formula is based on a first-order Taylor expansion
+    that becomes increasingly inaccurate at high occupancy. This function
+    evaluates the occupancy distribution and returns a warning level.
+
+    Parameters
+    ----------
+    occupancy : np.ndarray
+        Cumulative pixel occupancy probability values.
+    threshold_safe : float, optional
+        Occupancy threshold below which results are reliable. Default 0.50.
+    threshold_caution : float, optional
+        Occupancy threshold for caution level. Default 0.70.
+    threshold_warning : float, optional
+        Occupancy threshold for warning level. Default 0.90.
+
+    Returns
+    -------
+    OccupancyWarning
+        Dataclass containing warning level, statistics, and message.
+
+    Notes
+    -----
+    Warning levels:
+    - "safe" (P < 0.50): First-order approximation is accurate (<1% error)
+    - "caution" (0.50 <= P < 0.70): Approximation begins to diverge (1-5% error)
+    - "warning" (0.70 <= P < 0.90): Significant error possible (5-20% error)
+    - "critical" (P >= 0.90): First-order approximation breaks down (>20% error)
+
+    These thresholds were determined from Monte Carlo validation
+    (see notebooks/uncertainty_validation.ipynb).
+    """
+    occupancy = np.asarray(occupancy)
+    max_occ = float(np.max(occupancy))
+
+    # Calculate affected fractions
+    n_total = occupancy.size
+    n_above_safe = np.sum(occupancy >= threshold_safe)
+    affected_fraction = n_above_safe / n_total if n_total > 0 else 0.0
+
+    if max_occ < threshold_safe:
+        level = "safe"
+        message = f"Occupancy levels are safe (max: {max_occ:.1%}). Uncertainty estimates are reliable."
+    elif max_occ < threshold_caution:
+        level = "caution"
+        message = (
+            f"Some occupancy values exceed safe threshold (max: {max_occ:.1%}, "
+            f"{affected_fraction:.1%} of pixels affected). "
+            f"Uncertainty estimates may have 1-5% error."
+        )
+    elif max_occ < threshold_warning:
+        level = "warning"
+        message = (
+            f"High occupancy detected (max: {max_occ:.1%}, "
+            f"{affected_fraction:.1%} of pixels affected). "
+            f"Uncertainty estimates may have 5-20% error. "
+            f"Consider using Monte Carlo validation for critical results."
+        )
+    else:
+        level = "critical"
+        message = (
+            f"Critical occupancy levels detected (max: {max_occ:.1%}, "
+            f"{affected_fraction:.1%} of pixels affected). "
+            f"First-order approximation is unreliable (>20% error expected). "
+            f"Results should be validated with Monte Carlo simulation."
+        )
+
+    warning = OccupancyWarning(
+        level=level,
+        max_occupancy=max_occ,
+        affected_fraction=affected_fraction,
+        message=message,
+    )
+
+    # Log the warning
+    if level == "safe":
+        logger.debug(message)
+    elif level == "caution":
+        logger.info(message)
+    elif level == "warning":
+        logger.warning(message)
+    else:
+        logger.error(message)
+        warnings.warn(message, UserWarning)
+
+    return warning
+
+
+def aggregate_roi_uncertainty(
+    variance: np.ndarray,
+    roi_mask: Optional[np.ndarray] = None,
+    correlation_factor: float = 1.0,
+) -> Tuple[float, float]:
+    """Aggregate pixel uncertainties over a region of interest.
+
+    For ROI-averaged transmission, assuming independent pixels:
+
+        Var(T_ROI) = (1/N^2) * sum(Var(T_i)) = mean(Var(T_i)) / N
+
+    If pixels are correlated (e.g., due to beam structure), a correlation
+    factor can be applied to adjust the effective number of independent
+    measurements.
+
+    Parameters
+    ----------
+    variance : np.ndarray
+        Per-pixel variance values. Shape should be (height, width) for
+        a single frame or (n_frames, height, width) for multiple frames.
+    roi_mask : np.ndarray, optional
+        Boolean mask defining the ROI. True values indicate pixels to include.
+        If None, all pixels are included.
+    correlation_factor : float, optional
+        Factor to account for pixel correlations. Value of 1.0 assumes
+        independent pixels. Higher values indicate positive correlation
+        (fewer effective independent measurements). Default 1.0.
+
+    Returns
+    -------
+    Tuple[float, float]
+        (roi_variance, roi_std) - Variance and standard deviation of
+        the ROI-averaged transmission.
+
+    Notes
+    -----
+    The correlation factor affects the effective sample size:
+        N_eff = N / correlation_factor
+
+    For truly independent pixels, correlation_factor = 1.0.
+    For highly correlated pixels (e.g., within beam speckle size),
+    correlation_factor can be estimated from the autocorrelation
+    function of the image.
+
+    Examples
+    --------
+    >>> variance = np.ones((100, 100)) * 10.0  # uniform variance
+    >>> roi_mask = np.zeros((100, 100), dtype=bool)
+    >>> roi_mask[40:60, 40:60] = True  # 20x20 ROI = 400 pixels
+    >>> roi_var, roi_std = aggregate_roi_uncertainty(variance, roi_mask)
+    >>> # Expected: roi_var = 10.0 / 400 = 0.025
+    >>> np.isclose(roi_var, 0.025)
+    True
+    """
+    variance = np.asarray(variance, dtype=np.float64)
+
+    if roi_mask is not None:
+        roi_mask = np.asarray(roi_mask, dtype=bool)
+        # Handle broadcasting for 3D variance arrays
+        if variance.ndim == 3 and roi_mask.ndim == 2:
+            # Apply mask to each frame
+            roi_variance = variance[:, roi_mask]
+        else:
+            roi_variance = variance[roi_mask]
+        n_pixels = np.sum(roi_mask)
+    else:
+        roi_variance = variance.ravel()
+        n_pixels = variance.size
+
+    if n_pixels == 0:
+        return 0.0, 0.0
+
+    # Effective number of independent measurements
+    n_effective = n_pixels / correlation_factor
+
+    # For mean of N measurements with variances var_i:
+    # Var(mean) = sum(var_i) / N^2 = mean(var_i) / N
+    mean_variance = np.mean(roi_variance)
+    roi_var = mean_variance / n_effective
+
+    return float(roi_var), float(np.sqrt(roi_var))
+
+
+def calculate_relative_uncertainty(
+    transmission: np.ndarray,
+    std: np.ndarray,
+    min_transmission: float = 1e-10,
+) -> np.ndarray:
+    """Calculate relative uncertainty (coefficient of variation).
+
+    Parameters
+    ----------
+    transmission : np.ndarray
+        Corrected transmission values.
+    std : np.ndarray
+        Standard deviation of transmission values.
+    min_transmission : float, optional
+        Minimum transmission value to avoid division by zero. Default 1e-10.
+
+    Returns
+    -------
+    np.ndarray
+        Relative uncertainty (std / transmission), clipped to avoid infinities.
+    """
+    transmission = np.asarray(transmission, dtype=np.float64)
+    std = np.asarray(std, dtype=np.float64)
+
+    # Avoid division by zero
+    safe_transmission = np.maximum(np.abs(transmission), min_transmission)
+    relative = std / safe_transmission
+
+    return relative

--- a/src/ibeatles/core/detector/uncertainty.py
+++ b/src/ibeatles/core/detector/uncertainty.py
@@ -26,15 +26,13 @@ References
 - Validation notebook: notebooks/uncertainty_validation.ipynb
 """
 
-import logging
 import warnings
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Tuple, Union
 
 import numpy as np
-
-logger = logging.getLogger(__name__)
+from loguru import logger
 
 
 class ZeroCountMethod(Enum):

--- a/src/ibeatles/core/detector/uncertainty.py
+++ b/src/ibeatles/core/detector/uncertainty.py
@@ -267,7 +267,7 @@ def handle_zero_counts(
         shutter_n_ratio = np.asarray(shutter_n_ratio, dtype=np.float64)
         T_min = 1.0 / ((1.0 - occupancy) * shutter_n_ratio)
         zero_mask = transmission <= 0
-        T_effective[zero_mask] = T_min[zero_mask] if hasattr(T_min, "__getitem__") else T_min
+        T_effective = np.where(zero_mask, T_min, T_effective)
         return T_effective
 
     else:
@@ -412,6 +412,11 @@ def aggregate_roi_uncertainty(
     For highly correlated pixels (e.g., within beam speckle size),
     correlation_factor can be estimated from the autocorrelation
     function of the image.
+
+    For 3D input (n_frames, height, width), this function returns a single
+    aggregated value by averaging over all frames AND all ROI pixels. If you
+    need per-frame ROI uncertainties, call this function separately for each
+    frame slice: ``aggregate_roi_uncertainty(variance[i], roi_mask)``.
 
     Examples
     --------

--- a/tests/unit/ibeatles/core/detector/__init__.py
+++ b/tests/unit/ibeatles/core/detector/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+"""Unit tests for detector module."""

--- a/tests/unit/ibeatles/core/detector/test_uncertainty.py
+++ b/tests/unit/ibeatles/core/detector/test_uncertainty.py
@@ -303,13 +303,21 @@ class TestCalculateRelativeUncertainty:
         """Test that zero transmission doesn't cause division by zero."""
         transmission = np.array([0.0, 100.0])
         std = np.array([1.0, 10.0])
+        min_transmission = 1e-10  # default value
 
-        # Should not raise
         relative = calculate_relative_uncertainty(transmission, std)
 
-        # Zero transmission should give large but finite relative uncertainty
-        assert np.isfinite(relative[0])
-        assert np.isfinite(relative[1])
+        # Results should be finite
+        assert np.all(np.isfinite(relative))
+
+        # Zero transmission uses min_transmission as floor
+        # Expected: relative[0] = std[0] / min_transmission = 1.0 / 1e-10 = 1e10
+        expected_zero_case = std[0] / min_transmission
+        np.testing.assert_allclose(relative[0], expected_zero_case)
+
+        # Non-zero transmission should behave normally
+        expected_nonzero = std[1] / transmission[1]  # 10 / 100 = 0.1
+        np.testing.assert_allclose(relative[1], expected_nonzero)
 
 
 class TestIntegration:

--- a/tests/unit/ibeatles/core/detector/test_uncertainty.py
+++ b/tests/unit/ibeatles/core/detector/test_uncertainty.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python
+"""Unit tests for TPX1 detector uncertainty calculations."""
+
+import numpy as np
+import pytest
+
+from ibeatles.core.detector.uncertainty import (
+    OCCUPANCY_THRESHOLD_CAUTION,
+    OCCUPANCY_THRESHOLD_SAFE,
+    OCCUPANCY_THRESHOLD_WARNING,
+    ZeroCountMethod,
+    aggregate_roi_uncertainty,
+    calculate_relative_uncertainty,
+    calculate_transmission_std,
+    calculate_transmission_variance,
+    check_occupancy_validity,
+    handle_zero_counts,
+)
+
+
+class TestCalculateTransmissionVariance:
+    """Tests for calculate_transmission_variance function."""
+
+    def test_basic_variance_calculation(self):
+        """Test basic variance formula: Var(T) = T / ((1 - P) * s)."""
+        transmission = np.array([100.0, 150.0, 200.0])
+        occupancy = np.array([0.1, 0.2, 0.3])
+        shutter_n_ratio = 1.0
+
+        variance = calculate_transmission_variance(transmission, occupancy, shutter_n_ratio)
+
+        expected = transmission / ((1 - occupancy) * shutter_n_ratio)
+        np.testing.assert_allclose(variance, expected)
+
+    def test_variance_with_array_shutter_ratio(self):
+        """Test variance with per-frame shutter ratio."""
+        transmission = np.array([100.0, 150.0, 200.0])
+        occupancy = np.array([0.1, 0.2, 0.3])
+        shutter_n_ratio = np.array([1.0, 1.01, 1.05])
+
+        variance = calculate_transmission_variance(transmission, occupancy, shutter_n_ratio)
+
+        expected = transmission / ((1 - occupancy) * shutter_n_ratio)
+        np.testing.assert_allclose(variance, expected)
+
+    def test_variance_2d_array(self):
+        """Test variance calculation with 2D image data."""
+        transmission = np.ones((10, 10)) * 100.0
+        occupancy = np.ones((10, 10)) * 0.2
+        shutter_n_ratio = 1.0
+
+        variance = calculate_transmission_variance(transmission, occupancy, shutter_n_ratio)
+
+        assert variance.shape == (10, 10)
+        expected_value = 100.0 / (0.8 * 1.0)  # 125.0
+        np.testing.assert_allclose(variance, expected_value)
+
+    def test_variance_3d_array(self):
+        """Test variance calculation with 3D stack (frames, height, width)."""
+        n_frames, height, width = 5, 10, 10
+        transmission = np.ones((n_frames, height, width)) * 100.0
+        occupancy = np.linspace(0.1, 0.3, n_frames)[:, np.newaxis, np.newaxis]
+        occupancy = np.broadcast_to(occupancy, (n_frames, height, width)).copy()
+        shutter_n_ratio = 1.0
+
+        variance = calculate_transmission_variance(transmission, occupancy, shutter_n_ratio)
+
+        assert variance.shape == (n_frames, height, width)
+
+    def test_variance_rejects_high_occupancy(self):
+        """Test that occupancy >= 1.0 raises ValueError."""
+        transmission = np.array([100.0])
+        occupancy = np.array([1.0])  # Invalid
+        shutter_n_ratio = 1.0
+
+        with pytest.raises(ValueError, match="Occupancy values must be < 1.0"):
+            calculate_transmission_variance(transmission, occupancy, shutter_n_ratio)
+
+    def test_variance_rejects_negative_shutter_ratio(self):
+        """Test that non-positive shutter ratio raises ValueError."""
+        transmission = np.array([100.0])
+        occupancy = np.array([0.1])
+        shutter_n_ratio = 0.0  # Invalid
+
+        with pytest.raises(ValueError, match="Shutter ratio must be positive"):
+            calculate_transmission_variance(transmission, occupancy, shutter_n_ratio)
+
+    def test_variance_non_negative(self):
+        """Test that variance is always non-negative."""
+        transmission = np.array([0.0, 1.0, 100.0])
+        occupancy = np.array([0.1, 0.2, 0.3])
+        shutter_n_ratio = 1.0
+
+        variance = calculate_transmission_variance(transmission, occupancy, shutter_n_ratio)
+
+        assert np.all(variance >= 0)
+
+
+class TestCalculateTransmissionStd:
+    """Tests for calculate_transmission_std function."""
+
+    def test_std_is_sqrt_variance(self):
+        """Test that std equals sqrt(variance)."""
+        transmission = np.array([100.0, 150.0, 200.0])
+        occupancy = np.array([0.1, 0.2, 0.3])
+        shutter_n_ratio = 1.0
+
+        std = calculate_transmission_std(transmission, occupancy, shutter_n_ratio)
+        variance = calculate_transmission_variance(transmission, occupancy, shutter_n_ratio)
+
+        np.testing.assert_allclose(std, np.sqrt(variance))
+
+
+class TestHandleZeroCounts:
+    """Tests for handle_zero_counts function."""
+
+    def test_none_method_preserves_zeros(self):
+        """Test NONE method preserves zero values."""
+        transmission = np.array([0.0, 100.0, 0.0])
+        occupancy = np.array([0.1, 0.2, 0.3])
+        shutter_n_ratio = 1.0
+
+        result = handle_zero_counts(transmission, occupancy, shutter_n_ratio, ZeroCountMethod.NONE)
+
+        np.testing.assert_array_equal(result, transmission)
+
+    def test_anscombe_method(self):
+        """Test Anscombe transform adds 0.375."""
+        transmission = np.array([0.0, 100.0, 200.0])
+        occupancy = np.array([0.1, 0.2, 0.3])
+        shutter_n_ratio = 1.0
+
+        result = handle_zero_counts(transmission, occupancy, shutter_n_ratio, ZeroCountMethod.ANSCOMBE)
+
+        expected = transmission + 0.375
+        np.testing.assert_allclose(result, expected)
+
+    def test_small_constant_method(self):
+        """Test SMALL_CONSTANT method replaces zeros with 0.5."""
+        transmission = np.array([0.0, 100.0, 0.0])
+        occupancy = np.array([0.1, 0.2, 0.3])
+        shutter_n_ratio = 1.0
+
+        result = handle_zero_counts(transmission, occupancy, shutter_n_ratio, ZeroCountMethod.SMALL_CONSTANT)
+
+        expected = np.array([0.5, 100.0, 0.5])
+        np.testing.assert_allclose(result, expected)
+
+    def test_minimum_count_method(self):
+        """Test MINIMUM_COUNT method replaces zeros with T_min."""
+        transmission = np.array([0.0, 100.0, 0.0])
+        occupancy = np.array([0.1, 0.2, 0.3])
+        shutter_n_ratio = 1.0
+
+        result = handle_zero_counts(transmission, occupancy, shutter_n_ratio, ZeroCountMethod.MINIMUM_COUNT)
+
+        # T_min = 1 / ((1 - P) * s) for each zero position
+        T_min_0 = 1.0 / ((1.0 - 0.1) * 1.0)  # ~1.111
+        T_min_2 = 1.0 / ((1.0 - 0.3) * 1.0)  # ~1.429
+        expected = np.array([T_min_0, 100.0, T_min_2])
+        np.testing.assert_allclose(result, expected)
+
+
+class TestCheckOccupancyValidity:
+    """Tests for check_occupancy_validity function."""
+
+    def test_safe_occupancy(self):
+        """Test safe occupancy level detection."""
+        occupancy = np.random.uniform(0.0, 0.4, size=(100, 100))
+
+        warning = check_occupancy_validity(occupancy)
+
+        assert warning.level == "safe"
+        assert warning.max_occupancy < OCCUPANCY_THRESHOLD_SAFE
+
+    def test_caution_occupancy(self):
+        """Test caution occupancy level detection."""
+        occupancy = np.full((100, 100), 0.6)  # Between safe and caution thresholds
+
+        warning = check_occupancy_validity(occupancy)
+
+        assert warning.level == "caution"
+        assert OCCUPANCY_THRESHOLD_SAFE <= warning.max_occupancy < OCCUPANCY_THRESHOLD_CAUTION
+
+    def test_warning_occupancy(self):
+        """Test warning occupancy level detection."""
+        occupancy = np.full((100, 100), 0.8)  # Between caution and warning thresholds
+
+        warning = check_occupancy_validity(occupancy)
+
+        assert warning.level == "warning"
+        assert OCCUPANCY_THRESHOLD_CAUTION <= warning.max_occupancy < OCCUPANCY_THRESHOLD_WARNING
+
+    def test_critical_occupancy(self):
+        """Test critical occupancy level detection."""
+        occupancy = np.full((100, 100), 0.95)  # Above warning threshold
+
+        warning = check_occupancy_validity(occupancy)
+
+        assert warning.level == "critical"
+        assert warning.max_occupancy >= OCCUPANCY_THRESHOLD_WARNING
+
+    def test_affected_fraction_calculation(self):
+        """Test that affected fraction is calculated correctly."""
+        # Create array where 25% of pixels are above safe threshold
+        occupancy = np.zeros((10, 10))
+        occupancy[:5, :5] = 0.6  # 25 pixels above threshold
+
+        warning = check_occupancy_validity(occupancy)
+
+        assert warning.affected_fraction == 0.25
+
+    def test_warning_dataclass_fields(self):
+        """Test that OccupancyWarning has all expected fields."""
+        occupancy = np.array([0.3, 0.4, 0.5])
+
+        warning = check_occupancy_validity(occupancy)
+
+        assert hasattr(warning, "level")
+        assert hasattr(warning, "max_occupancy")
+        assert hasattr(warning, "affected_fraction")
+        assert hasattr(warning, "message")
+        assert isinstance(warning.message, str)
+
+
+class TestAggregateRoiUncertainty:
+    """Tests for aggregate_roi_uncertainty function."""
+
+    def test_full_array_aggregation(self):
+        """Test aggregation over entire array without mask."""
+        # 100 pixels with variance = 10 each
+        # Expected: roi_var = 10 / 100 = 0.1
+        variance = np.ones((10, 10)) * 10.0
+
+        roi_var, roi_std = aggregate_roi_uncertainty(variance)
+
+        np.testing.assert_allclose(roi_var, 0.1)
+        np.testing.assert_allclose(roi_std, np.sqrt(0.1))
+
+    def test_masked_aggregation(self):
+        """Test aggregation with ROI mask."""
+        variance = np.ones((10, 10)) * 10.0
+        roi_mask = np.zeros((10, 10), dtype=bool)
+        roi_mask[4:6, 4:6] = True  # 4 pixels
+
+        # Expected: roi_var = 10 / 4 = 2.5
+        roi_var, roi_std = aggregate_roi_uncertainty(variance, roi_mask)
+
+        np.testing.assert_allclose(roi_var, 2.5)
+        np.testing.assert_allclose(roi_std, np.sqrt(2.5))
+
+    def test_correlation_factor(self):
+        """Test that correlation factor reduces effective N."""
+        variance = np.ones((10, 10)) * 10.0  # 100 pixels
+
+        # Without correlation: roi_var = 10 / 100 = 0.1
+        roi_var_uncorrelated, _ = aggregate_roi_uncertainty(variance, correlation_factor=1.0)
+
+        # With correlation factor 2: N_eff = 50, roi_var = 10 / 50 = 0.2
+        roi_var_correlated, _ = aggregate_roi_uncertainty(variance, correlation_factor=2.0)
+
+        np.testing.assert_allclose(roi_var_uncorrelated, 0.1)
+        np.testing.assert_allclose(roi_var_correlated, 0.2)
+
+    def test_empty_roi(self):
+        """Test that empty ROI returns zeros."""
+        variance = np.ones((10, 10)) * 10.0
+        roi_mask = np.zeros((10, 10), dtype=bool)  # No pixels selected
+
+        roi_var, roi_std = aggregate_roi_uncertainty(variance, roi_mask)
+
+        assert roi_var == 0.0
+        assert roi_std == 0.0
+
+    def test_3d_variance_with_2d_mask(self):
+        """Test 3D variance array with 2D ROI mask."""
+        n_frames = 5
+        variance = np.ones((n_frames, 10, 10)) * 10.0
+        roi_mask = np.zeros((10, 10), dtype=bool)
+        roi_mask[4:6, 4:6] = True  # 4 pixels per frame
+
+        roi_var, roi_std = aggregate_roi_uncertainty(variance, roi_mask)
+
+        # mean(var) = 10, n_pixels = 4
+        # roi_var = 10 / 4 = 2.5
+        np.testing.assert_allclose(roi_var, 2.5)
+
+
+class TestCalculateRelativeUncertainty:
+    """Tests for calculate_relative_uncertainty function."""
+
+    def test_relative_uncertainty(self):
+        """Test relative uncertainty calculation."""
+        transmission = np.array([100.0, 200.0, 50.0])
+        std = np.array([10.0, 10.0, 10.0])
+
+        relative = calculate_relative_uncertainty(transmission, std)
+
+        expected = np.array([0.1, 0.05, 0.2])
+        np.testing.assert_allclose(relative, expected)
+
+    def test_handles_zero_transmission(self):
+        """Test that zero transmission doesn't cause division by zero."""
+        transmission = np.array([0.0, 100.0])
+        std = np.array([1.0, 10.0])
+
+        # Should not raise
+        relative = calculate_relative_uncertainty(transmission, std)
+
+        # Zero transmission should give large but finite relative uncertainty
+        assert np.isfinite(relative[0])
+        assert np.isfinite(relative[1])
+
+
+class TestIntegration:
+    """Integration tests for the uncertainty module."""
+
+    def test_full_uncertainty_pipeline(self):
+        """Test complete uncertainty calculation pipeline."""
+        # Simulate realistic data
+        n_frames = 100
+        height, width = 50, 50
+
+        # Corrected transmission (typical values 50-200)
+        np.random.seed(42)
+        transmission = np.random.uniform(50, 200, (n_frames, height, width))
+
+        # Occupancy increasing over frames (0.1 to 0.4)
+        occupancy = np.linspace(0.1, 0.4, n_frames)[:, np.newaxis, np.newaxis]
+        occupancy = np.broadcast_to(occupancy, (n_frames, height, width)).copy()
+
+        # Shutter ratio (slightly varying around 1.0)
+        shutter_n_ratio = np.linspace(1.0, 1.05, n_frames)[:, np.newaxis, np.newaxis]
+
+        # Calculate uncertainty
+        variance = calculate_transmission_variance(transmission, occupancy, shutter_n_ratio)
+        std = calculate_transmission_std(transmission, occupancy, shutter_n_ratio)
+
+        # Check occupancy validity
+        warning = check_occupancy_validity(occupancy)
+
+        # Aggregate over ROI
+        roi_mask = np.zeros((height, width), dtype=bool)
+        roi_mask[20:30, 20:30] = True  # 100 pixel ROI
+
+        roi_var, roi_std = aggregate_roi_uncertainty(variance, roi_mask)
+
+        # Assertions
+        assert variance.shape == transmission.shape
+        assert std.shape == transmission.shape
+        assert np.all(variance >= 0)
+        assert np.all(std >= 0)
+        assert warning.level == "safe"  # max occupancy is 0.4
+        assert roi_var > 0
+        assert roi_std > 0
+
+    def test_uncertainty_scales_with_occupancy(self):
+        """Test that uncertainty increases with occupancy (as expected)."""
+        transmission = 100.0
+        shutter_n_ratio = 1.0
+
+        occupancies = [0.1, 0.3, 0.5, 0.7]
+        variances = []
+
+        for occ in occupancies:
+            var = calculate_transmission_variance(
+                np.array([transmission]),
+                np.array([occ]),
+                shutter_n_ratio,
+            )
+            variances.append(var[0])
+
+        # Variance should increase with occupancy
+        for i in range(len(variances) - 1):
+            assert variances[i + 1] > variances[i], (
+                f"Variance should increase with occupancy: "
+                f"var({occupancies[i]})={variances[i]} vs var({occupancies[i + 1]})={variances[i + 1]}"
+            )
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])


### PR DESCRIPTION
## Summary

- Implement uncertainty propagation for TPX1 MCP detector efficiency correction
- Add variance formula: `Var(T) = T / ((1 - P) * s)` validated via Monte Carlo in PR #321
- Provide zero-count handling methods (None, Anscombe, small constant, minimum count)
- Add occupancy validity checking with warning levels (safe/caution/warning/critical)
- Include ROI uncertainty aggregation with pixel correlation factor support
- Add comprehensive unit tests (27 tests, all passing)

## Test plan

- [x] Run `pixi run python -m pytest tests/unit/ibeatles/core/detector/test_uncertainty.py -v`
- [x] Verify all 27 unit tests pass
- [x] Run `pixi run ruff check src/ibeatles/core/detector/` passes

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)