### PR TITLE
Add uncertainty calculation module for TPX1 detector (fresh start)

### DIFF
--- a/src/ibeatles/core/detector/__init__.py
+++ b/src/ibeatles/core/detector/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+"""Detector-specific modules for neutron imaging data processing.
+
+This package contains modules for TPX1 MCP detector uncertainty calculations.
+"""
+
+from ibeatles.core.detector.uncertainty import (
+    compute_counts_with_uncertainty,
+    load_shutter_counts,
+)
+
+__all__ = [
+    "compute_counts_with_uncertainty",
+    "load_shutter_counts",
+]

--- a/src/ibeatles/core/detector/uncertainty.py
+++ b/src/ibeatles/core/detector/uncertainty.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python
+"""Uncertainty calculations for TPX1 MCP detector-corrected data.
+
+This module computes uncertainty estimates for detector-efficiency-corrected
+neutron imaging data. It takes the corrected TIFF stack and metadata files
+as input, and outputs counts with uncertainty for a specified ROI.
+
+The uncertainty is derived from the detector correction formula:
+    T_i = F_i / ((1 - P_i) * s_i)
+
+Where:
+    - T_i: corrected counts (what the user has)
+    - F_i: raw counts (derived internally)
+    - P_i: cumulative pixel occupancy (derived internally)
+    - s_i: shutter normalization ratio (derived from shutter counts file)
+
+The variance formula (validated via Monte Carlo):
+    Var(T_i) = T_i / ((1 - P_i) * s_i)
+
+Usage
+-----
+>>> from ibeatles.core.detector import compute_counts_with_uncertainty
+>>> result = compute_counts_with_uncertainty(
+...     tiff_stack=corrected_images,  # shape: (n_frames, height, width)
+...     tof_array=tof_values,         # shape: (n_frames,)
+...     shutter_counts_file="path/to/ShutterCount.txt",
+...     roi_mask=roi,                 # shape: (height, width), boolean
+... )
+>>> result.to_csv("output.csv", index=False)
+
+References
+----------
+- Validation notebook: notebooks/uncertainty_validation.ipynb
+- Reference implementation: NeutronImagingScripts/neutronimaging/detector_correction.py
+"""
+
+from pathlib import Path
+from typing import Optional, Tuple, Union
+
+import numpy as np
+import pandas as pd
+from loguru import logger
+
+
+def load_shutter_counts(file_path: Union[str, Path]) -> pd.DataFrame:
+    """Load and parse shutter counts file.
+
+    Parameters
+    ----------
+    file_path : str or Path
+        Path to the shutter counts file (tab-separated, .txt extension).
+        Expected format: shutter_index<TAB>shutter_counts
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns:
+        - shutter_index: int
+        - shutter_counts: int (total neutron counts for this shutter period)
+        - shutter_n_ratio: float (shutter_counts / shutter_counts[0])
+
+    Notes
+    -----
+    Only rows with shutter_counts > 0 are included.
+    The shutter_n_ratio is derived as counts[i] / counts[0].
+    """
+    file_path = Path(file_path)
+    if not file_path.exists():
+        raise FileNotFoundError(f"Shutter counts file not found: {file_path}")
+
+    df = pd.read_csv(
+        file_path,
+        sep="\t",
+        names=["shutter_index", "shutter_counts"],
+    )
+    # Filter out zero-count entries
+    df = df[df["shutter_counts"] > 0].copy()
+
+    if len(df) == 0:
+        raise ValueError(f"No valid shutter counts found in {file_path}")
+
+    # Derive the normalization ratio
+    df["shutter_n_ratio"] = df["shutter_counts"] / df["shutter_counts"].values[0]
+
+    logger.info(
+        f"Loaded shutter counts: {len(df)} shutter periods, "
+        f"counts range [{df['shutter_counts'].min()}, {df['shutter_counts'].max()}]"
+    )
+
+    return df.reset_index(drop=True)
+
+
+def _recover_raw_counts(
+    corrected: np.ndarray,
+    shutter_counts: int,
+    shutter_n_ratio: Union[np.ndarray, float],
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Recover raw counts F_i from corrected counts T_i.
+
+    Uses the inversion formula derived from T_i = F_i / ((1 - P_i) * s_i):
+        F_i = T_i * s_i * (N - S_{i-1}) / (N + T_i * s_i)
+
+    Where S_{i-1} = cumsum of F_j for j < i.
+
+    Parameters
+    ----------
+    corrected : np.ndarray
+        Corrected counts T_i, shape (n_frames, height, width).
+    shutter_counts : int
+        Total shutter counts N for this shutter period.
+    shutter_n_ratio : np.ndarray or float
+        Shutter normalization ratio s_i. If array, shape (n_frames,).
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray]
+        (raw_counts, occupancy) - F_i and P_i arrays with same shape as input.
+    """
+    n_frames = corrected.shape[0]
+    N = float(shutter_counts)
+
+    # Handle scalar vs array shutter ratio
+    if np.isscalar(shutter_n_ratio):
+        s = np.full(n_frames, shutter_n_ratio)
+    else:
+        s = np.asarray(shutter_n_ratio)
+
+    # Initialize output arrays
+    raw = np.zeros_like(corrected, dtype=np.float64)
+    occupancy = np.zeros_like(corrected, dtype=np.float64)
+
+    # Iteratively compute F_i and P_i
+    cumsum_raw = np.zeros(corrected.shape[1:], dtype=np.float64)  # S_{i-1}
+
+    for i in range(n_frames):
+        T_i = corrected[i].astype(np.float64)
+        s_i = s[i]
+
+        # F_i = T_i * s_i * (N - S_{i-1}) / (N + T_i * s_i)
+        numerator = T_i * s_i * (N - cumsum_raw)
+        denominator = N + T_i * s_i
+
+        # Avoid division by zero
+        with np.errstate(divide="ignore", invalid="ignore"):
+            F_i = np.where(denominator > 0, numerator / denominator, 0.0)
+
+        raw[i] = F_i
+
+        # Update cumsum for next iteration
+        cumsum_raw = cumsum_raw + F_i
+
+        # P_i = cumsum(F) / N (including current frame)
+        occupancy[i] = cumsum_raw / N
+
+    return raw, occupancy
+
+
+def _compute_variance(
+    corrected: np.ndarray,
+    occupancy: np.ndarray,
+    shutter_n_ratio: Union[np.ndarray, float],
+) -> np.ndarray:
+    """Compute variance of corrected counts.
+
+    Var(T_i) = T_i / ((1 - P_i) * s_i)
+
+    Parameters
+    ----------
+    corrected : np.ndarray
+        Corrected counts T_i.
+    occupancy : np.ndarray
+        Pixel occupancy probability P_i.
+    shutter_n_ratio : np.ndarray or float
+        Shutter normalization ratio s_i.
+
+    Returns
+    -------
+    np.ndarray
+        Variance array with same shape as input.
+    """
+    # Broadcast shutter ratio if needed
+    if np.isscalar(shutter_n_ratio):
+        s = shutter_n_ratio
+    else:
+        s = np.asarray(shutter_n_ratio)
+        if s.ndim == 1:
+            # Shape (n_frames,) -> (n_frames, 1, 1) for broadcasting
+            s = s[:, np.newaxis, np.newaxis]
+
+    # Compute variance
+    denominator = (1.0 - occupancy) * s
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        variance = np.where(denominator > 0, corrected / denominator, 0.0)
+
+    # Ensure non-negative
+    variance = np.maximum(variance, 0.0)
+
+    return variance
+
+
+def compute_counts_with_uncertainty(
+    tiff_stack: np.ndarray,
+    tof_array: np.ndarray,
+    shutter_counts_file: Union[str, Path],
+    roi_mask: Optional[np.ndarray] = None,
+    shutter_index: int = 0,
+) -> pd.DataFrame:
+    """Compute counts with uncertainty for a region of interest.
+
+    This is the main entry point for uncertainty calculation. It takes
+    the detector-efficiency-corrected TIFF stack and metadata files,
+    computes the uncertainty, and returns a DataFrame ready for export.
+
+    Parameters
+    ----------
+    tiff_stack : np.ndarray
+        Detector-efficiency-corrected image stack, shape (n_frames, height, width).
+        These are the T_i values from the correction formula.
+    tof_array : np.ndarray
+        Time-of-flight values for each frame, shape (n_frames,).
+        Can be obtained from load_time_spectra()["tof_array"].
+    shutter_counts_file : str or Path
+        Path to the shutter counts file.
+    roi_mask : np.ndarray, optional
+        Boolean mask defining the ROI, shape (height, width).
+        If None, uses all pixels.
+    shutter_index : int, optional
+        Which shutter period to use (default 0, the first).
+        For single-shutter acquisitions, use 0.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns:
+        - tof: Time-of-flight values
+        - counts: Summed counts in ROI
+        - uncertainty: Uncertainty (standard deviation) of summed counts
+
+    Examples
+    --------
+    >>> # Load data using existing iBeatles functions
+    >>> data = load_data_from_folder("/path/to/corrected/tiffs")
+    >>> spectra = load_time_spectra(spectra_file, distance, offset)
+    >>>
+    >>> # Define ROI (e.g., 100x100 box in center)
+    >>> roi = np.zeros((512, 512), dtype=bool)
+    >>> roi[200:300, 200:300] = True
+    >>>
+    >>> # Compute uncertainty
+    >>> result = compute_counts_with_uncertainty(
+    ...     tiff_stack=data["data"],
+    ...     tof_array=spectra["tof_array"],
+    ...     shutter_counts_file="/path/to/ShutterCount.txt",
+    ...     roi_mask=roi,
+    ... )
+    >>>
+    >>> # Export to CSV
+    >>> result.to_csv("counts_with_uncertainty.csv", index=False)
+    """
+    # Validate inputs
+    tiff_stack = np.asarray(tiff_stack, dtype=np.float64)
+    tof_array = np.asarray(tof_array)
+
+    if tiff_stack.ndim != 3:
+        raise ValueError(f"tiff_stack must be 3D (n_frames, height, width), got shape {tiff_stack.shape}")
+
+    n_frames, height, width = tiff_stack.shape
+
+    if len(tof_array) != n_frames:
+        raise ValueError(f"tof_array length ({len(tof_array)}) must match number of frames ({n_frames})")
+
+    # Load shutter metadata
+    shutter_df = load_shutter_counts(shutter_counts_file)
+
+    if shutter_index >= len(shutter_df):
+        raise ValueError(
+            f"shutter_index {shutter_index} out of range (only {len(shutter_df)} shutter periods available)"
+        )
+
+    shutter_counts = int(shutter_df.loc[shutter_index, "shutter_counts"])
+    shutter_n_ratio = float(shutter_df.loc[shutter_index, "shutter_n_ratio"])
+
+    logger.info(f"Using shutter period {shutter_index}: counts={shutter_counts}, ratio={shutter_n_ratio:.4f}")
+
+    # Create ROI mask if not provided
+    if roi_mask is None:
+        roi_mask = np.ones((height, width), dtype=bool)
+        logger.info("No ROI mask provided, using all pixels")
+    else:
+        roi_mask = np.asarray(roi_mask, dtype=bool)
+        if roi_mask.shape != (height, width):
+            raise ValueError(f"roi_mask shape {roi_mask.shape} must match image shape ({height}, {width})")
+        n_pixels = np.sum(roi_mask)
+        logger.info(f"ROI contains {n_pixels} pixels")
+
+    # Recover raw counts and compute occupancy
+    logger.info("Computing occupancy from corrected counts...")
+    _, occupancy = _recover_raw_counts(tiff_stack, shutter_counts, shutter_n_ratio)
+
+    # Compute variance
+    logger.info("Computing variance...")
+    variance = _compute_variance(tiff_stack, occupancy, shutter_n_ratio)
+
+    # Aggregate over ROI
+    logger.info("Aggregating over ROI...")
+    counts_per_frame = np.zeros(n_frames)
+    variance_per_frame = np.zeros(n_frames)
+
+    for i in range(n_frames):
+        # Sum counts in ROI
+        counts_per_frame[i] = np.sum(tiff_stack[i][roi_mask])
+        # Sum variances (pixels assumed independent)
+        variance_per_frame[i] = np.sum(variance[i][roi_mask])
+
+    # Standard deviation = sqrt(variance)
+    uncertainty_per_frame = np.sqrt(variance_per_frame)
+
+    # Build output DataFrame
+    result = pd.DataFrame(
+        {
+            "tof": tof_array,
+            "counts": counts_per_frame,
+            "uncertainty": uncertainty_per_frame,
+        }
+    )
+
+    logger.info(f"Computed uncertainty for {n_frames} frames")
+
+    return result

--- a/src/ibeatles/core/detector/uncertainty.py
+++ b/src/ibeatles/core/detector/uncertainty.py
@@ -268,6 +268,9 @@ def compute_counts_with_uncertainty(
 
     n_frames, height, width = tiff_stack.shape
 
+    if n_frames == 0:
+        raise ValueError("tiff_stack must contain at least one frame")
+
     if len(tof_array) != n_frames:
         raise ValueError(f"tof_array length ({len(tof_array)}) must match number of frames ({n_frames})")
 
@@ -280,6 +283,11 @@ def compute_counts_with_uncertainty(
     shutter_counts = int(shutter_df.loc[shutter_index, "shutter_counts"])
     shutter_n_ratio = float(shutter_df.loc[shutter_index, "shutter_n_ratio"])
 
+    if shutter_counts <= 0:
+        raise ValueError(f"shutter_counts must be positive, got {shutter_counts}")
+    if shutter_n_ratio <= 0:
+        raise ValueError(f"shutter_n_ratio must be positive, got {shutter_n_ratio}")
+
     logger.info(f"Using shutter period {shutter_index}: counts={shutter_counts}, ratio={shutter_n_ratio:.4f}")
 
     # Create ROI mask if not provided
@@ -291,6 +299,8 @@ def compute_counts_with_uncertainty(
         if roi_mask.shape != (height, width):
             raise ValueError(f"roi_mask shape {roi_mask.shape} must match image shape ({height}, {width})")
         n_pixels = np.sum(roi_mask)
+        if n_pixels == 0:
+            raise ValueError("roi_mask must contain at least one pixel")
         logger.info(f"ROI contains {n_pixels} pixels")
 
     # Recover raw counts and compute occupancy

--- a/src/ibeatles/core/detector/uncertainty.py
+++ b/src/ibeatles/core/detector/uncertainty.py
@@ -140,9 +140,10 @@ def _recover_raw_counts(
         numerator = T_i * s_i * (N - cumsum_raw)
         denominator = N + T_i * s_i
 
-        # Avoid division by zero
+        # Avoid division by zero and negative counts
+        # (numerator can be negative if cumsum_raw exceeds N due to numerical issues)
         with np.errstate(divide="ignore", invalid="ignore"):
-            F_i = np.where(denominator > 0, numerator / denominator, 0.0)
+            F_i = np.where((denominator > 0) & (numerator >= 0), numerator / denominator, 0.0)
 
         raw[i] = F_i
 
@@ -273,10 +274,8 @@ def compute_counts_with_uncertainty(
     # Load shutter metadata
     shutter_df = load_shutter_counts(shutter_counts_file)
 
-    if shutter_index >= len(shutter_df):
-        raise ValueError(
-            f"shutter_index {shutter_index} out of range (only {len(shutter_df)} shutter periods available)"
-        )
+    if shutter_index < 0 or shutter_index >= len(shutter_df):
+        raise ValueError(f"shutter_index {shutter_index} out of range (must be 0 to {len(shutter_df) - 1})")
 
     shutter_counts = int(shutter_df.loc[shutter_index, "shutter_counts"])
     shutter_n_ratio = float(shutter_df.loc[shutter_index, "shutter_n_ratio"])

--- a/tests/unit/ibeatles/core/detector/__init__.py
+++ b/tests/unit/ibeatles/core/detector/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+"""Unit tests for detector module."""

--- a/tests/unit/ibeatles/core/detector/test_uncertainty.py
+++ b/tests/unit/ibeatles/core/detector/test_uncertainty.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python
+"""Unit tests for TPX1 detector uncertainty calculations."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from ibeatles.core.detector.uncertainty import (
+    _compute_variance,
+    _recover_raw_counts,
+    compute_counts_with_uncertainty,
+    load_shutter_counts,
+)
+
+
+class TestLoadShutterCounts:
+    """Tests for load_shutter_counts function."""
+
+    def test_loads_valid_file(self, tmp_path):
+        """Test loading a valid shutter counts file."""
+        # Create test file
+        file_path = tmp_path / "ShutterCount.txt"
+        file_path.write_text("0\t100000\n1\t101000\n2\t105000\n3\t0\n4\t0\n")
+
+        df = load_shutter_counts(file_path)
+
+        # Should have 3 rows (zeros filtered out)
+        assert len(df) == 3
+        assert list(df.columns) == ["shutter_index", "shutter_counts", "shutter_n_ratio"]
+
+        # Check values
+        assert df.loc[0, "shutter_counts"] == 100000
+        assert df.loc[1, "shutter_counts"] == 101000
+        assert df.loc[2, "shutter_counts"] == 105000
+
+        # Check ratio calculation
+        assert df.loc[0, "shutter_n_ratio"] == 1.0
+        assert df.loc[1, "shutter_n_ratio"] == pytest.approx(1.01)
+        assert df.loc[2, "shutter_n_ratio"] == pytest.approx(1.05)
+
+    def test_raises_on_missing_file(self):
+        """Test that FileNotFoundError is raised for missing file."""
+        with pytest.raises(FileNotFoundError):
+            load_shutter_counts("/nonexistent/path/ShutterCount.txt")
+
+    def test_raises_on_empty_file(self, tmp_path):
+        """Test that ValueError is raised if no valid counts."""
+        file_path = tmp_path / "ShutterCount.txt"
+        file_path.write_text("0\t0\n1\t0\n")
+
+        with pytest.raises(ValueError, match="No valid shutter counts"):
+            load_shutter_counts(file_path)
+
+
+class TestRecoverRawCounts:
+    """Tests for _recover_raw_counts function."""
+
+    def test_simple_case(self):
+        """Test recovery with simple uniform data."""
+        # Create simple test case: 5 frames, 2x2 pixels
+        # All corrected values = 100, shutter_counts = 1000000 (low occupancy)
+        n_frames, height, width = 5, 2, 2
+        corrected = np.full((n_frames, height, width), 100.0)
+        shutter_counts = 1000000
+        shutter_n_ratio = 1.0
+
+        raw, occupancy = _recover_raw_counts(corrected, shutter_counts, shutter_n_ratio)
+
+        # Check shapes
+        assert raw.shape == corrected.shape
+        assert occupancy.shape == corrected.shape
+
+        # With low occupancy, raw should be close to corrected
+        # F_i ≈ T_i when P_i ≈ 0
+        assert np.allclose(raw[0], corrected[0], rtol=0.01)
+
+        # Occupancy should increase with frame index
+        for i in range(1, n_frames):
+            assert np.all(occupancy[i] > occupancy[i - 1])
+
+    def test_occupancy_increases_monotonically(self):
+        """Test that occupancy increases with each frame."""
+        n_frames, height, width = 10, 4, 4
+        corrected = np.random.uniform(50, 150, (n_frames, height, width))
+        shutter_counts = 500000
+        shutter_n_ratio = 1.0
+
+        _, occupancy = _recover_raw_counts(corrected, shutter_counts, shutter_n_ratio)
+
+        # Occupancy should be monotonically increasing
+        for i in range(1, n_frames):
+            assert np.all(occupancy[i] >= occupancy[i - 1])
+
+    def test_with_varying_shutter_ratio(self):
+        """Test with array of shutter ratios."""
+        n_frames, height, width = 3, 2, 2
+        corrected = np.full((n_frames, height, width), 100.0)
+        shutter_counts = 1000000
+        shutter_n_ratio = np.array([1.0, 1.01, 1.02])
+
+        raw, occupancy = _recover_raw_counts(corrected, shutter_counts, shutter_n_ratio)
+
+        # Should complete without error
+        assert raw.shape == corrected.shape
+        assert occupancy.shape == corrected.shape
+
+
+class TestComputeVariance:
+    """Tests for _compute_variance function."""
+
+    def test_variance_formula(self):
+        """Test that variance follows Var(T) = T / ((1 - P) * s)."""
+        corrected = np.array([[[100.0, 200.0], [150.0, 50.0]]])
+        occupancy = np.array([[[0.1, 0.2], [0.15, 0.05]]])
+        shutter_n_ratio = 1.0
+
+        variance = _compute_variance(corrected, occupancy, shutter_n_ratio)
+
+        expected = corrected / ((1 - occupancy) * shutter_n_ratio)
+        np.testing.assert_allclose(variance, expected)
+
+    def test_variance_increases_with_occupancy(self):
+        """Test that variance increases with higher occupancy."""
+        corrected = np.full((1, 2, 2), 100.0)
+        occupancy_low = np.full((1, 2, 2), 0.1)
+        occupancy_high = np.full((1, 2, 2), 0.5)
+        shutter_n_ratio = 1.0
+
+        var_low = _compute_variance(corrected, occupancy_low, shutter_n_ratio)
+        var_high = _compute_variance(corrected, occupancy_high, shutter_n_ratio)
+
+        assert np.all(var_high > var_low)
+
+    def test_variance_non_negative(self):
+        """Test that variance is always non-negative."""
+        corrected = np.random.uniform(0, 200, (10, 4, 4))
+        occupancy = np.random.uniform(0, 0.8, (10, 4, 4))
+        shutter_n_ratio = 1.0
+
+        variance = _compute_variance(corrected, occupancy, shutter_n_ratio)
+
+        assert np.all(variance >= 0)
+
+
+class TestComputeCountsWithUncertainty:
+    """Tests for compute_counts_with_uncertainty function."""
+
+    @pytest.fixture
+    def shutter_file(self, tmp_path):
+        """Create a temporary shutter counts file."""
+        file_path = tmp_path / "ShutterCount.txt"
+        file_path.write_text("0\t200000\n1\t0\n2\t0\n")
+        return file_path
+
+    def test_basic_usage(self, shutter_file):
+        """Test basic usage with synthetic data."""
+        n_frames, height, width = 10, 8, 8
+        tiff_stack = np.random.uniform(50, 150, (n_frames, height, width))
+        tof_array = np.linspace(1000, 2000, n_frames)
+
+        result = compute_counts_with_uncertainty(
+            tiff_stack=tiff_stack,
+            tof_array=tof_array,
+            shutter_counts_file=shutter_file,
+        )
+
+        # Check output structure
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == ["tof", "counts", "uncertainty"]
+        assert len(result) == n_frames
+
+        # Check values are reasonable
+        assert np.all(result["counts"] > 0)
+        assert np.all(result["uncertainty"] > 0)
+        assert np.all(np.isfinite(result["counts"]))
+        assert np.all(np.isfinite(result["uncertainty"]))
+
+    def test_with_roi_mask(self, shutter_file):
+        """Test with ROI mask."""
+        n_frames, height, width = 5, 10, 10
+        tiff_stack = np.ones((n_frames, height, width)) * 100.0
+        tof_array = np.arange(n_frames)
+
+        # Create ROI: 4x4 box = 16 pixels
+        roi_mask = np.zeros((height, width), dtype=bool)
+        roi_mask[3:7, 3:7] = True
+
+        result = compute_counts_with_uncertainty(
+            tiff_stack=tiff_stack,
+            tof_array=tof_array,
+            shutter_counts_file=shutter_file,
+            roi_mask=roi_mask,
+        )
+
+        # Counts should be 16 pixels * 100 = 1600 per frame
+        np.testing.assert_allclose(result["counts"], 1600.0)
+
+    def test_uncertainty_scales_with_roi_size(self, shutter_file):
+        """Test that smaller ROI has larger relative uncertainty."""
+        n_frames, height, width = 5, 20, 20
+        tiff_stack = np.ones((n_frames, height, width)) * 100.0
+        tof_array = np.arange(n_frames)
+
+        # Small ROI: 2x2 = 4 pixels
+        roi_small = np.zeros((height, width), dtype=bool)
+        roi_small[9:11, 9:11] = True
+
+        # Large ROI: 10x10 = 100 pixels
+        roi_large = np.zeros((height, width), dtype=bool)
+        roi_large[5:15, 5:15] = True
+
+        result_small = compute_counts_with_uncertainty(
+            tiff_stack=tiff_stack,
+            tof_array=tof_array,
+            shutter_counts_file=shutter_file,
+            roi_mask=roi_small,
+        )
+
+        result_large = compute_counts_with_uncertainty(
+            tiff_stack=tiff_stack,
+            tof_array=tof_array,
+            shutter_counts_file=shutter_file,
+            roi_mask=roi_large,
+        )
+
+        # Relative uncertainty should be larger for smaller ROI
+        rel_unc_small = result_small["uncertainty"] / result_small["counts"]
+        rel_unc_large = result_large["uncertainty"] / result_large["counts"]
+
+        assert np.all(rel_unc_small > rel_unc_large)
+
+    def test_raises_on_shape_mismatch(self, shutter_file):
+        """Test that shape mismatches raise errors."""
+        tiff_stack = np.ones((10, 8, 8))
+        tof_array = np.arange(5)  # Wrong length
+
+        with pytest.raises(ValueError, match="tof_array length"):
+            compute_counts_with_uncertainty(
+                tiff_stack=tiff_stack,
+                tof_array=tof_array,
+                shutter_counts_file=shutter_file,
+            )
+
+    def test_raises_on_invalid_roi_shape(self, shutter_file):
+        """Test that invalid ROI shape raises error."""
+        tiff_stack = np.ones((10, 8, 8))
+        tof_array = np.arange(10)
+        roi_mask = np.ones((4, 4), dtype=bool)  # Wrong shape
+
+        with pytest.raises(ValueError, match="roi_mask shape"):
+            compute_counts_with_uncertainty(
+                tiff_stack=tiff_stack,
+                tof_array=tof_array,
+                shutter_counts_file=shutter_file,
+                roi_mask=roi_mask,
+            )
+
+
+class TestIntegration:
+    """Integration tests simulating real workflow."""
+
+    def test_round_trip_consistency(self, tmp_path):
+        """Test that the pipeline produces consistent results."""
+        # Create shutter file
+        shutter_file = tmp_path / "ShutterCount.txt"
+        shutter_file.write_text("0\t500000\n")
+
+        # Create synthetic data
+        np.random.seed(42)
+        n_frames, height, width = 20, 16, 16
+        tiff_stack = np.random.uniform(80, 120, (n_frames, height, width))
+        tof_array = np.linspace(1000, 5000, n_frames)
+
+        # Full image (no ROI)
+        result1 = compute_counts_with_uncertainty(
+            tiff_stack=tiff_stack,
+            tof_array=tof_array,
+            shutter_counts_file=shutter_file,
+        )
+
+        # Run again - should get same result
+        result2 = compute_counts_with_uncertainty(
+            tiff_stack=tiff_stack,
+            tof_array=tof_array,
+            shutter_counts_file=shutter_file,
+        )
+
+        pd.testing.assert_frame_equal(result1, result2)
+
+    def test_csv_export(self, tmp_path):
+        """Test that result can be exported to CSV."""
+        # Create shutter file
+        shutter_file = tmp_path / "ShutterCount.txt"
+        shutter_file.write_text("0\t200000\n")
+
+        # Create data
+        n_frames = 10
+        tiff_stack = np.ones((n_frames, 4, 4)) * 100.0
+        tof_array = np.arange(n_frames)
+
+        result = compute_counts_with_uncertainty(
+            tiff_stack=tiff_stack,
+            tof_array=tof_array,
+            shutter_counts_file=shutter_file,
+        )
+
+        # Export to CSV
+        csv_path = tmp_path / "output.csv"
+        result.to_csv(csv_path, index=False)
+
+        # Read back and verify
+        loaded = pd.read_csv(csv_path)
+        assert list(loaded.columns) == ["tof", "counts", "uncertainty"]
+        assert len(loaded) == n_frames
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])


### PR DESCRIPTION
## Summary

This is a fresh implementation after PR #322 was closed due to fundamental design issues (see #322 close comment for post-mortem).

**What this module does:**
- Takes the user's actual inputs: TIFF stack (corrected), TOF array, shutter counts file, ROI
- Internally derives occupancy and shutter ratio from shutter counts file
- Outputs a DataFrame with columns: `tof`, `counts`, `uncertainty`

**Key functions:**
- `load_shutter_counts(file_path)`: Parse shutter counts file, compute shutter_n_ratio
- `compute_counts_with_uncertainty(tiff_stack, tof_array, shutter_counts_file, roi_mask)`: Main entry point

**Example usage:**
```python
from ibeatles.core.detector import compute_counts_with_uncertainty

result = compute_counts_with_uncertainty(
    tiff_stack=data["data"],           # from load_data_from_folder()
    tof_array=spectra["tof_array"],    # from load_time_spectra()
    shutter_counts_file="ShutterCount.txt",
    roi_mask=roi,
)
result.to_csv("counts_with_uncertainty.csv", index=False)
```

**Design decisions learned from PR #322:**
- Build tools that solve the user's actual problem with the data they actually have
- Don't build abstract math utilities requiring pre-computed inputs
- Derive everything internally that can be derived

## Test plan

- [x] Run `pixi run python -m pytest tests/unit/ibeatles/core/detector/test_uncertainty.py -v`
- [x] All 16 tests pass
- [x] `pixi run ruff check` passes

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)