### PR TITLE
Add dev conda build & publish workflow

### DIFF
--- a/.github/workflows/dev-conda-publish.yaml
+++ b/.github/workflows/dev-conda-publish.yaml
@@ -1,0 +1,88 @@
+name: dev conda build and publish
+
+on:
+  push:
+    branches: [next]
+
+# cancel previous job if new commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dev-conda-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: prefix-dev/setup-pixi@v0.8.3
+        with:
+          pixi-version: v0.62.0
+          manifest-path: pyproject.toml
+      - name: build conda package
+        run: |
+          echo "Build conda package"
+          pixi run build-conda
+      - name: upload conda package to anaconda with dev label
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+        run: |
+          echo "Uploading dev conda package"
+          pixi run anaconda upload --label dev --user neutronimaging conda.recipe/noarch/ibeatles*.tar.bz2
+      - name: cleanup old dev packages
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+        run: |
+          # Get all files for the package, filter dev-labeled ones,
+          # group by version keeping newest upload_time per version, sort descending
+          DEV_VERSIONS=$(curl -s https://api.anaconda.org/package/neutronimaging/ibeatles \
+            | jq -r '
+              [.files[] | select(.labels | index("dev"))]
+              | group_by(.version)
+              | map({version: .[0].version, upload_time: (map(.upload_time) | max)})
+              | sort_by(.upload_time)
+              | reverse
+              | .[].version
+            ')
+
+          echo "Dev versions (newest first):"
+          echo "$DEV_VERSIONS"
+
+          # Keep the 5 most recent, remove the rest
+          COUNT=0
+          for VERSION in $DEV_VERSIONS; do
+            COUNT=$((COUNT + 1))
+            if [ $COUNT -le 5 ]; then
+              echo "Keeping version: $VERSION"
+            else
+              echo "Removing old dev version: $VERSION"
+              pixi run anaconda remove --force neutronimaging/ibeatles/$VERSION
+            fi
+          done
+
+  # Trigger GitLab dev deploy pipeline
+  deploy-dev:
+    runs-on: ubuntu-latest
+    needs: dev-conda-build
+    steps:
+      - name: Get Environment Name
+        uses: neutrons/branch-mapper@main
+        id: env_name
+        with:
+          prefix: ibeatles
+
+      - name: Trigger Dev Deploy
+        uses: eic/trigger-gitlab-ci@d984d8d53d871d2fdc1325639d94322da6e8747f
+        id: trigger
+        with:
+          url: https://code.ornl.gov
+          project_id: 18010
+          ref_name: main
+          token: ${{ secrets.GITLAB_DEPLOY_TOKEN }}
+
+      - name: Annotate commit
+        uses: peter-evans/commit-comment@v4
+        with:
+          body: |
+            GitLab pipeline for ${{ steps.env_name.outputs.name }} has been submitted for this commit: ${{ steps.trigger.outputs.web_url }}

--- a/.github/workflows/dev-conda-publish.yaml
+++ b/.github/workflows/dev-conda-publish.yaml
@@ -29,37 +29,38 @@ jobs:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
         run: |
           echo "Uploading dev conda package"
-          pixi run anaconda upload --label dev --user neutronimaging conda.recipe/noarch/ibeatles*.tar.bz2
+          pixi run anaconda upload --force --label dev --user neutronimaging conda.recipe/noarch/ibeatles*.tar.bz2
       - name: cleanup old dev packages
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
         run: |
-          # Get all files for the package, filter dev-labeled ones,
-          # group by version keeping newest upload_time per version, sort descending
-          DEV_VERSIONS=$(curl -s https://api.anaconda.org/package/neutronimaging/ibeatles \
+          # Get all dev-labeled files, group by version, sort by newest upload time descending.
+          # Output format: one line per file as "version full_name" for versions beyond the 5 newest.
+          FILES_TO_REMOVE=$(curl -s https://api.anaconda.org/package/neutronimaging/ibeatles \
             | jq -r '
               [.files[] | select(.labels | index("dev"))]
               | group_by(.version)
-              | map({version: .[0].version, upload_time: (map(.upload_time) | max)})
+              | map({
+                  version: .[0].version,
+                  upload_time: (map(.upload_time) | max),
+                  files: [.[].full_name]
+                })
               | sort_by(.upload_time)
               | reverse
-              | .[].version
+              | .[5:]
+              | .[].files[]
             ')
 
-          echo "Dev versions (newest first):"
-          echo "$DEV_VERSIONS"
-
-          # Keep the 5 most recent, remove the rest
-          COUNT=0
-          for VERSION in $DEV_VERSIONS; do
-            COUNT=$((COUNT + 1))
-            if [ $COUNT -le 5 ]; then
-              echo "Keeping version: $VERSION"
-            else
-              echo "Removing old dev version: $VERSION"
-              pixi run anaconda remove --force neutronimaging/ibeatles/$VERSION
-            fi
-          done
+          if [ -z "$FILES_TO_REMOVE" ]; then
+            echo "No old dev packages to clean up"
+          else
+            echo "Removing old dev files:"
+            echo "$FILES_TO_REMOVE"
+            for FILE in $FILES_TO_REMOVE; do
+              echo "Removing: $FILE"
+              pixi run anaconda remove --force "$FILE"
+            done
+          fi
 
   # Trigger GitLab dev deploy pipeline
   deploy-dev:


### PR DESCRIPTION
## Summary

- Adds a new GitHub Actions workflow that automatically builds and publishes conda packages with a `dev` label on every push to the `next` branch
- Includes cleanup of old dev packages on anaconda.org, keeping only the 5 most recent dev versions
- Triggers GitLab CI deployment after the conda upload completes, ensuring the dev environment stays current

Users can install dev builds with:
```bash
conda install -c neutronimaging/label/dev -c conda-forge ibeatles
```

## Test plan

- [ ] Merge to `next` and verify the workflow triggers
- [ ] Confirm the conda package appears on `anaconda.org/neutronimaging/ibeatles` with the `dev` label
- [ ] Verify cleanup step correctly identifies and removes old dev versions (keeping 5 most recent)
- [ ] Verify the GitLab deployment pipeline is triggered after upload
- [ ] Test installation: `conda install -c neutronimaging/label/dev -c conda-forge ibeatles`

🤖 Generated with [Claude Code](https://claude.com/claude-code)