### PR TITLE
Pin NeuNorm to v1.6.12 (stopgap for NeuNorm 2.0 break)

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -23,7 +23,7 @@ build:
     - {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
     - {{ PYTHON }} -m pip install git+https://github.com/ornlneutronimaging/BraggEdge.git --no-deps --no-build-isolation -vvv
     - {{ PYTHON }} -m pip install git+https://github.com/ruipgil/changepy.git --no-deps --no-build-isolation -vvv
-    - {{ PYTHON }} -m pip install git+https://github.com/ornlneutronimaging/NeuNorm.git --no-deps --no-build-isolation -vvv
+    - {{ PYTHON }} -m pip install git+https://github.com/ornlneutronimaging/NeuNorm.git@v1.6.12 --no-deps --no-build-isolation -vvv
 
 requirements:
 


### PR DESCRIPTION
Pins the unpinned `git+NeuNorm` install in `conda.recipe/meta.yaml` to the last NeuNorm 1.x release **`@v1.6.12`**.

NeuNorm 2.0 merged into its `next` on 2026-06-04 (NeuNorm PR #124), switching to the Hatchling backend and a breaking API. The unpinned install started pulling 2.0, breaking the conda build (`Cannot import 'hatchling.build'`) on every PR. This restores the intended 1.x dependency (setuptools backend) and unblocks CI.

Stopgap for #412 (full context + 2.0 port plan); supersedes the `add hatchling` idea in #411. Exact pre-2.0 `next` commit is `1d4d1d4` if a SHA pin is preferred over the release tag.

Assisted-With: Claude Opus 4.8 (1M context)