### PR TITLE
fix: pin neunorm to pre-2.0 in environment.yml (refs #412)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,8 @@ dependencies:
   # compute
   - astropy
   - lmfit
-  - neunorm
+  # NeuNorm 2.0 (on the neutronimaging channel) is a breaking rewrite — see #412
+  - neunorm>=1.6.12,<2
   # storage
   - h5py
   - sqlite


### PR DESCRIPTION
## Summary

`environment.yml` was the last unpinned NeuNorm reference in this repo. NeuNorm **2.0.0 is now published on the `neutronimaging` conda channel** (and PyPI), so `- neunorm` resolves to the breaking scipp-based rewrite today.

This pins it to `>=1.6.12,<2`, matching the existing pins in `pyproject.toml` and `conda.recipe/meta.yaml`.

Stopgap for #412 (full 2.0 port tracked there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)