### PR TITLE
fix(ci): grant contents:write to deploy-dev for commit annotation

### DIFF
--- a/.github/workflows/dev-conda-publish.yaml
+++ b/.github/workflows/dev-conda-publish.yaml
@@ -69,6 +69,8 @@ jobs:
   deploy-dev:
     runs-on: ubuntu-latest
     needs: dev-conda-build
+    permissions:
+      contents: write  # commit comments require contents:write
     steps:
       - name: Get Environment Name
         uses: neutrons/branch-mapper@010ccbc2818a0c720a62d29cae8b85c54a49375e  # pin to main


### PR DESCRIPTION
## What

One-job permissions fix in `dev-conda-publish.yaml`: the `deploy-dev` job now has `permissions: contents: write`.

## Why

The #416 hardening set the workflow to `contents: read` top-level. On the first `next` push after that (the #417 dependabot merge, run [27433460512](https://github.com/ornlneutronimaging/iBeatles/actions/runs/27433460512)), the final **Annotate commit** step (`peter-evans/commit-comment`) failed with `403 Resource not accessible by integration` — creating a commit comment requires `contents: write`.

**Delivery impact: none.** The GitLab trigger step succeeded before the annotation failed, so the dev deploy pipeline for the analysis cluster fired normally; only the cosmetic commit-comment annotation was lost.

The grant is scoped to the `deploy-dev` job only; `dev-conda-build` stays at the top-level `contents: read`.

Checked HyperCTui / CGC / NIS for the same pattern — no other repo uses `commit-comment`, so this is iBeatles-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)