### PR TITLE
feat: port normalization to NeuNorm 2.0 (route a, #412)

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -23,7 +23,6 @@ build:
     - {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
     - {{ PYTHON }} -m pip install git+https://github.com/ornlneutronimaging/BraggEdge.git@2.0.6 --no-deps --no-build-isolation -vvv
     - {{ PYTHON }} -m pip install git+https://github.com/ruipgil/changepy.git@bf53e3a4af182b38b9c08fc56a0c6e68c2d33bda --no-deps --no-build-isolation -vvv
-    - {{ PYTHON }} -m pip install git+https://github.com/ornlneutronimaging/NeuNorm.git@v1.6.12 --no-deps --no-build-isolation -vvv
 
 requirements:
 
@@ -57,7 +56,10 @@ requirements:
     - tqdm
     - tomli
     - pydantic
-    # - neutronimaging::neunorm  # switch to pip install until we sorted out NeuNorm conda package version issue
+    - scipp
+    # 2.0 publishes a clean conda package to the neutronimaging channel,
+    # so the pip-vendoring workaround used for 1.x is gone (#412)
+    - neunorm >=2.0.0,<3
 
 about:
   home: {{ url }}

--- a/environment.yml
+++ b/environment.yml
@@ -22,8 +22,9 @@ dependencies:
   # compute
   - astropy
   - lmfit
-  # NeuNorm 2.0 (on the neutronimaging channel) is a breaking rewrite — see #412
-  - neunorm>=1.6.12,<2
+  # NeuNorm 2.0 port landed with #412 — scipp comes with it
+  - neunorm>=2.0.0,<3
+  - scipp
   # storage
   - h5py
   - sqlite

--- a/pixi.lock
+++ b/pixi.lock
@@ -64,6 +64,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.26.11-h6d08254_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.26.11-h29cf534_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.17.0-h84d6215_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha829cd9_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.0-h6083320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h87a9417_105.conda
@@ -117,6 +118,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.5.0-h8d2ee43_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-3.5.0-hdbdcf42_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.78.1-h1d1128b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.13.0-default_he001693_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
@@ -214,12 +216,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.15-h6a952e8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.3-hc5a330e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipp-26.3.1-py312h92aac4d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/simdjson-4.6.4-hb700be7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sip-6.10.0-py312h1289d80_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.17.0-hab81395_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.2-hbc0de68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py312hd9148b4_0.conda
@@ -430,6 +434,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1f/22/28f62d24f7db56ac4343588f9362d49b7b4177e55ac47a466fe696b0099b/polars-1.41.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/21/cc/2d77af4fff86012f334ef82e6d54a995a86c8745e58074f1218ed7d25171/duckdb-1.5.3-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/25/19/69aebbd92b8db4a1a19d39397167e2df5f6ed44b1dad0005ca604e78901f/sqlglotc-30.8.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/29/47/23b3ea13967dd512f3c0da27257df5e18e9ecdfeae4d14e1f3900ea2ce20/neunorm-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2d/76/51b57a2e521b9110f25ec935f2774412e2f3d678b3fdea7841987244fb2c/marimo-0.23.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/91/30151a39f7570f448ed84529390628a651d7f27c87d73c9b887f8189695e/docutils-0.23-py3-none-any.whl
@@ -440,10 +445,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6a/1d/c03cecf9c48040f750c6e5b4f027fb4935cc41d9b76f1217af7731f4dc2b/pydantic_ai_slim-1.104.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6c/c6/92b352fe88cf51bd0a19fb99e1c0cbe46aa26c14dcf7995b89869cd932ae/polars_runtime_32-1.41.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/78/f9/690a8600b93c332de3ab4a344a4ac34f00c8f104917061f779db6a918ed6/pathlib-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/4e/80705091aaf9c95e125d243f0aa871bc9f3670b4c9d963e6bad3b3dce8ff/sqlglot-30.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/97/b9/639818adb83dad11e9b21b4ad1906883b98732b06959257e33f7d7f14db9/logfire_api-4.34.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/47/72fd8b2e60a957c9dc1c9a6171a9b016a45120e7f258851f16b940c731a5/scitiff-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/70/00dc4246d9f3c69ecbb9bc36d5ad1a359884464a44711c665cb0afb1e9de/loro-1.10.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -456,7 +462,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/63/5dacc8d8306c715088b897a479e551bc0779fd2f0f26c97fec5e36542b4e/altair-6.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/ec/b08dc2e834ca00fd8dfedcb17ae2e920667adaad617b45e32b7a3b146f24/genai_prices-0.0.61-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ea/e0/d22c19d7474492992e5fda4ae4c66f3e8680e09d2f66bdc7f2b9d0d50d00/neunorm-1.6.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f4/1e/2c9096fc19d5fd084b0184ca2b651e659aa0a37e6fdbecf6ece47f147fe1/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       osx-arm64:
@@ -673,6 +678,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.14-hec049ff_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gst-plugins-base-1.26.11-hda1d4dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gstreamer-1.26.11-h087694b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gtest-1.15.2-h420ef59_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.16.0-nompi_py312h585e8c8_102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.0-h3103d1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_he586413_105.conda
@@ -714,6 +720,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.5.0-h688a705_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.5.0-ha114238_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.78.1-h3e3f78d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.13.0-default_ha97f43a_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.25.1-h493aca8_0.conda
@@ -801,12 +808,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.17-py312hb3ab3e3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py312hb3ab3e3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.15.15-h80928e0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipp-25.12.0-py312hec401e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py312h4519d97_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/simdjson-4.6.4-h4ddebb9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sip-6.15.3-py312h6d95f44_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.17.0-ha0f8610_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.53.2-h77b7338_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2023.0.0-he0260a5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.7-py312h2bbb03f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.1.0-py312h766f71e_0.conda
@@ -834,6 +843,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/fd/0318007beb234790993d3ec5afd051d1dbceb733e81e3afe2b981ece3f37/python_multipart-0.0.30-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1f/22/28f62d24f7db56ac4343588f9362d49b7b4177e55ac47a466fe696b0099b/polars-1.41.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/29/47/23b3ea13967dd512f3c0da27257df5e18e9ecdfeae4d14e1f3900ea2ce20/neunorm-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2d/76/51b57a2e521b9110f25ec935f2774412e2f3d678b3fdea7841987244fb2c/marimo-0.23.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/91/30151a39f7570f448ed84529390628a651d7f27c87d73c9b887f8189695e/docutils-0.23-py3-none-any.whl
@@ -849,11 +859,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/6d/81/074612945c0666078f7366f40000013de9f6ba687491d450df699bceebc9/msgspec-0.21.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/78/e4/7b614260bf16c5e33c0bea6ac47ab0284efd21f89f2e5e4e15cd93bead40/loro-1.10.3-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/78/f9/690a8600b93c332de3ab4a344a4ac34f00c8f104917061f779db6a918ed6/pathlib-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/4e/80705091aaf9c95e125d243f0aa871bc9f3670b4c9d963e6bad3b3dce8ff/sqlglot-30.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/d7/3be4a163a35aeecffc75d8f93f59c4378c6ae85185f21086ac640edf6f12/sqlglotc-30.8.0-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/97/b9/639818adb83dad11e9b21b4ad1906883b98732b06959257e33f7d7f14db9/logfire_api-4.34.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/47/72fd8b2e60a957c9dc1c9a6171a9b016a45120e7f258851f16b940c731a5/scitiff-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/ba/3418133ba144dfcd1530bca5a6b695f4cdd21a8abaaa2ac4e5450d11b028/astropy-7.2.0-cp311-abi3-macosx_11_0_arm64.whl
@@ -864,7 +875,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/63/5dacc8d8306c715088b897a479e551bc0779fd2f0f26c97fec5e36542b4e/altair-6.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/ec/b08dc2e834ca00fd8dfedcb17ae2e920667adaad617b45e32b7a3b146f24/genai_prices-0.0.61-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ea/e0/d22c19d7474492992e5fda4ae4c66f3e8680e09d2f66bdc7f2b9d0d50d00/neunorm-1.6.12-py3-none-any.whl
   jupyter:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -922,6 +932,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.26.11-h6d08254_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.26.11-h29cf534_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.17.0-h84d6215_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha829cd9_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.0-h6083320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h87a9417_105.conda
@@ -974,6 +985,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.5.0-h8d2ee43_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-3.5.0-hdbdcf42_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.78.1-h1d1128b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.13.0-default_he001693_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
@@ -1057,10 +1069,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-2026.5.1-py312h192e038_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.3-hc5a330e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipp-26.3.1-py312h92aac4d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sip-6.10.0-py312h1289d80_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.2-hbc0de68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
@@ -1261,11 +1275,12 @@ environments:
       - pypi: .
       - pypi: https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/09/fe/f61e7129e9e689d9e40bbf8a36fb90f04eceb477f4617c02c6a18463e81f/configparser-7.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/29/47/23b3ea13967dd512f3c0da27257df5e18e9ecdfeae4d14e1f3900ea2ce20/neunorm-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/1b/86cddfc25214090fa0c07f0c1716bcd201c40dbfaf79bc9a184a238206d9/neutronbraggedge-2.0.6-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/78/f9/690a8600b93c332de3ab4a344a4ac34f00c8f104917061f779db6a918ed6/pathlib-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/47/72fd8b2e60a957c9dc1c9a6171a9b016a45120e7f258851f16b940c731a5/scitiff-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/1c/f06ad85180e7dd9855aa5ede901bfc2be858d7bee17d4e978a14c0ecec14/astropy-7.2.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a7/dede35a22f31785ef06be5384c3597bce3be086f03ce263c2d08f2c5d5cd/changepy-0.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ea/e0/d22c19d7474492992e5fda4ae4c66f3e8680e09d2f66bdc7f2b9d0d50d00/neunorm-1.6.12-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-3.7.0-pyhcf101f3_0.conda
@@ -1480,6 +1495,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.14-hec049ff_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gst-plugins-base-1.26.11-hda1d4dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gstreamer-1.26.11-h087694b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gtest-1.15.2-h420ef59_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.16.0-nompi_py312h585e8c8_102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.0-h3103d1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_he586413_105.conda
@@ -1520,6 +1536,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.5.0-h688a705_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.5.0-ha114238_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.78.1-h3e3f78d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.13.0-default_ha97f43a_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.25.1-h493aca8_0.conda
@@ -1595,10 +1612,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2025.11.05-ha480c28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-2026.5.1-py312h8b1d842_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipp-25.12.0-py312hec401e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py312h4519d97_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sip-6.15.3-py312h6d95f44_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.53.2-h77b7338_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2023.0.0-he0260a5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.7-py312h2bbb03f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-17.0.1-py312h2bbb03f_0.conda
@@ -1613,12 +1632,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: .
       - pypi: https://files.pythonhosted.org/packages/09/fe/f61e7129e9e689d9e40bbf8a36fb90f04eceb477f4617c02c6a18463e81f/configparser-7.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/29/47/23b3ea13967dd512f3c0da27257df5e18e9ecdfeae4d14e1f3900ea2ce20/neunorm-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/1b/86cddfc25214090fa0c07f0c1716bcd201c40dbfaf79bc9a184a238206d9/neutronbraggedge-2.0.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/78/f9/690a8600b93c332de3ab4a344a4ac34f00c8f104917061f779db6a918ed6/pathlib-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/47/72fd8b2e60a957c9dc1c9a6171a9b016a45120e7f258851f16b940c731a5/scitiff-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/ba/3418133ba144dfcd1530bca5a6b695f4cdd21a8abaaa2ac4e5450d11b028/astropy-7.2.0-cp311-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a7/dede35a22f31785ef06be5384c3597bce3be086f03ce263c2d08f2c5d5cd/changepy-0.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ea/e0/d22c19d7474492992e5fda4ae4c66f3e8680e09d2f66bdc7f2b9d0d50d00/neunorm-1.6.12-py3-none-any.whl
   package:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -1680,6 +1700,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.26.11-h6d08254_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.26.11-h29cf534_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.17.0-h84d6215_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha829cd9_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h735b18d_107.conda
@@ -1733,6 +1754,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.5.0-h8d2ee43_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-3.5.0-hdbdcf42_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.78.1-h1d1128b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.13.0-default_he001693_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
@@ -1833,11 +1855,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.17-py312h5253ce2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.3-hc5a330e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipp-26.3.1-py312h92aac4d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.5.0-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sip-6.10.0-py312h1289d80_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.2-hbc0de68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
@@ -2060,11 +2084,12 @@ environments:
       - pypi: .
       - pypi: https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/09/fe/f61e7129e9e689d9e40bbf8a36fb90f04eceb477f4617c02c6a18463e81f/configparser-7.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/29/47/23b3ea13967dd512f3c0da27257df5e18e9ecdfeae4d14e1f3900ea2ce20/neunorm-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/1b/86cddfc25214090fa0c07f0c1716bcd201c40dbfaf79bc9a184a238206d9/neutronbraggedge-2.0.6-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/78/f9/690a8600b93c332de3ab4a344a4ac34f00c8f104917061f779db6a918ed6/pathlib-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/47/72fd8b2e60a957c9dc1c9a6171a9b016a45120e7f258851f16b940c731a5/scitiff-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/1c/f06ad85180e7dd9855aa5ede901bfc2be858d7bee17d4e978a14c0ecec14/astropy-7.2.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a7/dede35a22f31785ef06be5384c3597bce3be086f03ce263c2d08f2c5d5cd/changepy-0.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ea/e0/d22c19d7474492992e5fda4ae4c66f3e8680e09d2f66bdc7f2b9d0d50d00/neunorm-1.6.12-py3-none-any.whl
   py312:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -2121,6 +2146,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.26.11-h6d08254_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.26.11-h29cf534_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.17.0-h84d6215_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha829cd9_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h735b18d_107.conda
@@ -2173,6 +2199,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.5.0-h8d2ee43_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-3.5.0-hdbdcf42_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.78.1-h1d1128b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.13.0-default_he001693_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
@@ -2254,10 +2281,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h5301d42_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.3-hc5a330e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipp-26.3.1-py312h92aac4d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sip-6.10.0-py312h1289d80_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.2-hbc0de68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
@@ -2414,11 +2443,16 @@ environments:
       - pypi: .
       - pypi: https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/09/fe/f61e7129e9e689d9e40bbf8a36fb90f04eceb477f4617c02c6a18463e81f/configparser-7.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/29/47/23b3ea13967dd512f3c0da27257df5e18e9ecdfeae4d14e1f3900ea2ce20/neunorm-2.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/1b/86cddfc25214090fa0c07f0c1716bcd201c40dbfaf79bc9a184a238206d9/neutronbraggedge-2.0.6-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/78/f9/690a8600b93c332de3ab4a344a4ac34f00c8f104917061f779db6a918ed6/pathlib-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/47/72fd8b2e60a957c9dc1c9a6171a9b016a45120e7f258851f16b940c731a5/scitiff-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/1c/f06ad85180e7dd9855aa5ede901bfc2be858d7bee17d4e978a14c0ecec14/astropy-7.2.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a7/dede35a22f31785ef06be5384c3597bce3be086f03ce263c2d08f2c5d5cd/changepy-0.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ea/e0/d22c19d7474492992e5fda4ae4c66f3e8680e09d2f66bdc7f2b9d0d50d00/neunorm-1.6.12-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f4/1e/2c9096fc19d5fd084b0184ca2b651e659aa0a37e6fdbecf6ece47f147fe1/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-3.7.0-pyhcf101f3_0.conda
@@ -2588,6 +2622,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.15-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gst-plugins-base-1.26.11-hda1d4dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gstreamer-1.26.11-h087694b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gtest-1.15.2-h420ef59_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.16.0-nompi_py312h585e8c8_102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.1-h3103d1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_h9bfbf6c_107.conda
@@ -2628,6 +2663,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.5.0-h688a705_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.5.0-ha114238_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.78.1-h3e3f78d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.13.0-default_ha97f43a_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.25.1-h493aca8_0.conda
@@ -2699,10 +2735,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qt-webengine-5.15.15-h5422c0a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2025.11.05-ha480c28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipp-25.12.0-py312hec401e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py312h4519d97_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sip-6.15.3-py312h6d95f44_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.53.2-h77b7338_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2023.0.0-he0260a5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.7-py312h2bbb03f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-17.0.1-py312h2bbb03f_0.conda
@@ -2717,12 +2755,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: .
       - pypi: https://files.pythonhosted.org/packages/09/fe/f61e7129e9e689d9e40bbf8a36fb90f04eceb477f4617c02c6a18463e81f/configparser-7.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/29/47/23b3ea13967dd512f3c0da27257df5e18e9ecdfeae4d14e1f3900ea2ce20/neunorm-2.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/1b/86cddfc25214090fa0c07f0c1716bcd201c40dbfaf79bc9a184a238206d9/neutronbraggedge-2.0.6-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/78/f9/690a8600b93c332de3ab4a344a4ac34f00c8f104917061f779db6a918ed6/pathlib-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/47/72fd8b2e60a957c9dc1c9a6171a9b016a45120e7f258851f16b940c731a5/scitiff-26.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a6/ba/3418133ba144dfcd1530bca5a6b695f4cdd21a8abaaa2ac4e5450d11b028/astropy-7.2.0-cp311-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a7/dede35a22f31785ef06be5384c3597bce3be086f03ce263c2d08f2c5d5cd/changepy-0.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ea/e0/d22c19d7474492992e5fda4ae4c66f3e8680e09d2f66bdc7f2b9d0d50d00/neunorm-1.6.12-py3-none-any.whl
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -3846,6 +3889,19 @@ packages:
   purls: []
   size: 2281638
   timestamp: 1776268376145
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.17.0-h84d6215_1.conda
+  sha256: 1f738280f245863c5ac78bcc04bb57266357acda45661c4aa25823030c6fb5db
+  md5: 55e29b72a71339bc651f9975492db71f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  constrains:
+  - gmock 1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 416610
+  timestamp: 1748320117187
 - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha829cd9_102.conda
   sha256: 578ab0db104435ac003061e103789299720fc49b8b3e8401dabd5130a1ef8663
   md5: c6e5cf708b01707fe4cd5e4dc56cf4cc
@@ -4778,6 +4834,19 @@ packages:
   purls: []
   size: 7021360
   timestamp: 1774020290672
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.13.0-default_he001693_1000.conda
+  sha256: 5041d295813dfb84652557839825880aae296222ab725972285c5abe3b6e4288
+  md5: c197985b58bc813d26b42881f0021c82
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2436378
+  timestamp: 1770953868164
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
   sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
   md5: 915f5995e94f60e9a4826e0b0920ee88
@@ -6431,6 +6500,22 @@ packages:
   purls: []
   size: 388111
   timestamp: 1778113913631
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipp-26.3.1-py312h92aac4d_1.conda
+  sha256: 85eb92a68a9b85255d789365ee194ccc696952d79a44aa1a8318c7409be410bb
+  md5: 4b9faa3fba4c554c7e5e87557e0d9a68
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gtest >=1.17.0,<1.17.1.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - tbb >=2022.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8800452
+  timestamp: 1777042016097
 - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_1.conda
   sha256: d5ac05ad45c0d48731eb189c2cbb2bb99f0e3cb7e1acaad373cb2f1f2597fc75
   md5: 15995ecb2ef890778ba9a3750190f09d
@@ -6531,6 +6616,18 @@ packages:
   license: blessing
   size: 205545
   timestamp: 1780574435288
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
+  sha256: 30cb9355c2fefc20ff1a3d6566b9714d5614086a2524c07721fc344eb20515ae
+  md5: 7073b15f9364ebc118998601ac6ca6a6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libhwloc >=2.13.0,<2.13.1.0a0
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
+  size: 182331
+  timestamp: 1778673758649
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
   sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
   md5: cffd3bdd58090148f4cfcd831f4b26ab
@@ -11334,6 +11431,18 @@ packages:
   purls: []
   size: 2013777
   timestamp: 1776268446977
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gtest-1.15.2-h420ef59_0.conda
+  sha256: 7295d84430024bd36da657c5b82a2b9759d5a335b6d5ef9b7f4b58b96ba8b6c9
+  md5: 539e1126f517d18d5c26b7c460374297
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  constrains:
+  - gmock 1.15.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 373673
+  timestamp: 1722458126696
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.16.0-nompi_py312h585e8c8_102.conda
   sha256: 2ac08cff564c3b49f8a7f21eb9abdb81cad2fe2270ed1d48a5be05416d99f40c
   md5: d5c7d8decb6113045ac8168f66ad1de2
@@ -12128,6 +12237,18 @@ packages:
   purls: []
   size: 4820402
   timestamp: 1774012715207
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.13.0-default_ha97f43a_1000.conda
+  sha256: d47c3c030671d196ff1cdd343e93eb2ae0d7b665cb79f8164cc91488796db437
+  md5: fed55ddd65a830cb62e78f07cfffcd41
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2339152
+  timestamp: 1770953916323
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
   sha256: de0336e800b2af9a40bdd694b03870ac4a848161b35c8a2325704f123f185f03
   md5: 4d5a7445f0b25b6a3ddbb56e790f5251
@@ -13450,6 +13571,22 @@ packages:
   - pkg:pypi/ruff?source=compressed-mapping
   size: 8424737
   timestamp: 1780055998652
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipp-25.12.0-py312hec401e3_0.conda
+  sha256: ef7f28ecd62e6cbff54fadfa342820e7ae1316624728b7e811d593fbb2a99d21
+  md5: 39a31f678227b27057364e36a1aa8065
+  depends:
+  - __osx >=11.0
+  - gtest >=1.15.2,<1.15.3.0a0
+  - libcxx >=19
+  - numpy
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - tbb >=2022.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5126916
+  timestamp: 1766165628774
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py312h4519d97_1.conda
   sha256: c0ed2cbfa3485bac8570e52b577475778c603ee92d078a8b164d1ddec992e577
   md5: 173d5eeba324363d9171946e86a81687
@@ -13532,6 +13669,17 @@ packages:
   license: blessing
   size: 182162
   timestamp: 1780575254663
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2023.0.0-he0260a5_2.conda
+  sha256: 6f72a2984052444b9381020fa329b83dace95f335573dc21199f1b1d1a5f5473
+  md5: 440c0a36cc20db1f28877a69afbb5e88
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libhwloc >=2.13.0,<2.13.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 122303
+  timestamp: 1778675142610
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
   sha256: 799cab4b6cde62f91f750149995d149bc9db525ec12595e8a1d91b9317f038b3
   md5: a9d86bc62f39b94c4661716624eb21b0
@@ -13727,9 +13875,10 @@ packages:
   - qtpy
   - pyqt5
   - pyqtgraph
+  - scipp
   - neutronbraggedge>=2.0.6,<3
   - changepy>=0.4.0,<0.5
-  - neunorm>=1.6.12,<2
+  - neunorm>=2.0.0,<3
   requires_python: '>=3.12,<3.13'
 - pypi: https://files.pythonhosted.org/packages/01/84/c01099b59a285a1ebba64ae93f62bfa036675340fd1b0045ae65890a0442/jiter-0.15.0-cp312-cp312-macosx_11_0_arm64.whl
   name: jiter
@@ -13921,6 +14070,30 @@ packages:
   - setuptools-scm ; extra == 'dev'
   - sqlglot-mypy>=1.20.0.post6 ; extra == 'dev'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/29/47/23b3ea13967dd512f3c0da27257df5e18e9ecdfeae4d14e1f3900ea2ce20/neunorm-2.0.0-py3-none-any.whl
+  name: neunorm
+  version: 2.0.0
+  sha256: 30e4c5c2549067e92815c6ce456974ea8911c35fe39f2db60d528154b3919bf0
+  requires_dist:
+  - astropy
+  - h5py>=3.0
+  - loguru>=0.7
+  - numpy>=2.0,<3
+  - pillow
+  - pydantic>=2.0
+  - scipp>=25.8.0
+  - scipy>=1.11
+  - scitiff>=26.1
+  - tqdm
+  - myst-parser ; extra == 'docs'
+  - nbsphinx ; extra == 'docs'
+  - sphinx ; extra == 'docs'
+  - sphinx-rtd-theme ; extra == 'docs'
+  - versioningit ; extra == 'docs'
+  - numba>=0.60 ; extra == 'performance'
+  - matplotlib ; extra == 'viz'
+  - plopp>=25.10.0 ; extra == 'viz'
+  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
   name: referencing
   version: 0.37.0
@@ -14159,10 +14332,6 @@ packages:
   version: 1.10.3
   sha256: 5253b8f436d90412b373c583f22ac9539cfb495bf88f78d4bb41daafef0830b7
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/78/f9/690a8600b93c332de3ab4a344a4ac34f00c8f104917061f779db6a918ed6/pathlib-1.0.1-py3-none-any.whl
-  name: pathlib
-  version: 1.0.1
-  sha256: f35f95ab8b0f59e6d354090350b44a80a80635d22efdedfa84c7ad1cf0a74147
 - pypi: https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl
   name: pymdown-extensions
   version: 10.21.3
@@ -14172,6 +14341,42 @@ packages:
   - pyyaml
   - pygments>=2.19.1 ; extra == 'extra'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
+  name: tifffile
+  version: 2026.6.1
+  sha256: 0d7382d2769b855b81ce358528e2b40c16d48aa39031746efa81215205332a8d
+  requires_dist:
+  - numpy>=2.1
+  - imagecodecs>=2026.5.10 ; extra == 'codecs'
+  - lxml ; extra == 'xml'
+  - zarr>=3.2.0 ; extra == 'zarr'
+  - fsspec ; extra == 'zarr'
+  - kerchunk ; extra == 'zarr'
+  - matplotlib ; extra == 'plot'
+  - imagecodecs>=2026.5.10 ; extra == 'all'
+  - matplotlib ; extra == 'all'
+  - lxml ; extra == 'all'
+  - zarr>=3.2.0 ; extra == 'all'
+  - xarray ; extra == 'all'
+  - fsspec ; extra == 'all'
+  - kerchunk ; extra == 'all'
+  - cmapfile ; extra == 'test'
+  - czifile ; extra == 'test'
+  - dask ; extra == 'test'
+  - fsspec ; extra == 'test'
+  - imagecodecs ; extra == 'test'
+  - kerchunk ; extra == 'test'
+  - lfdfiles ; extra == 'test'
+  - lxml ; extra == 'test'
+  - ndtiff ; extra == 'test'
+  - oiffile ; extra == 'test'
+  - psdtags ; extra == 'test'
+  - pytest ; extra == 'test'
+  - requests ; extra == 'test'
+  - roifile ; extra == 'test'
+  - xarray ; extra == 'test'
+  - zarr>=3.2.0 ; extra == 'test'
+  requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/88/4e/80705091aaf9c95e125d243f0aa871bc9f3670b4c9d963e6bad3b3dce8ff/sqlglot-30.8.0-py3-none-any.whl
   name: sqlglot
   version: 30.8.0
@@ -14210,6 +14415,18 @@ packages:
   version: 4.34.0
   sha256: ca51498bb60e1e4505c90cc20f949d2d6dcf9d15cf5fd5a46f14016f2f638c4c
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/9f/47/72fd8b2e60a957c9dc1c9a6171a9b016a45120e7f258851f16b940c731a5/scitiff-26.1.0-py3-none-any.whl
+  name: scitiff
+  version: 26.1.0
+  sha256: 816ec1d90feeacc5e4ebba136c4d42833e3566a480c4d6087944381139c0cbb1
+  requires_dist:
+  - scipp>=24.11.0
+  - tifffile>=2024.7.2
+  - jsonschema>=4.23.0
+  - pydantic>=2.11
+  - pytest>=8.0 ; extra == 'test'
+  - textual ; extra == 'gui'
+  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl
   name: rpds-py
   version: 2026.5.1
@@ -14513,17 +14730,6 @@ packages:
   - rich>=14.3.2 ; extra == 'cli'
   - rich-argparse>=1.7.2 ; extra == 'cli'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/ea/e0/d22c19d7474492992e5fda4ae4c66f3e8680e09d2f66bdc7f2b9d0d50d00/neunorm-1.6.12-py3-none-any.whl
-  name: neunorm
-  version: 1.6.12
-  sha256: b39694cf0916f8c82660654f383f763f59eb286e04df33f762a474b5f04da327
-  requires_dist:
-  - numpy
-  - pillow
-  - pathlib
-  - astropy
-  - scipy
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: jiter
   version: 0.15.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,12 @@ dependencies = [
   "QtPy",
   "PyQt5",
   "pyqtgraph",
+  # scipp carries the DataArrays the NeuNorm 2.0 normalization runs on
+  "scipp",
   # These are the dependencies from our neutron imaging team
   "neutronbraggedge>=2.0.6,<3",
   "changepy>=0.4.0,<0.5",
-  "neunorm>=1.6.12,<2",
+  "neunorm>=2.0.0,<3",
 ]
 
 [project.urls]
@@ -136,6 +138,7 @@ loguru = "*"
 tqdm = "*"
 tomli = "*"
 pydantic = "*"
+scipp = "*"
 pyqtgraph = "*"
 qt = "*"
 qtpy = "*"

--- a/src/ibeatles/about/about_launcher.py
+++ b/src/ibeatles/about/about_launcher.py
@@ -43,25 +43,11 @@ class AboutLauncher(QDialog):
             list_version.append(f"pandas: {pandas.__version__}")
 
         try:
-            import NeuNorm
+            import neunorm
         except ImportError:
-            list_version.append("NeuNorm: unknown")
+            list_version.append("neunorm: unknown")
         else:
-            list_version.append(f"NeuNorm: {NeuNorm.__version__}")
-
-        try:
-            import qtpy
-        except ImportError:
-            list_version.append("qtpy: unknown")
-        else:
-            list_version.append(f"qtpy: {qtpy.__version__}")
-
-        try:
-            import NeuNorm
-        except ImportError:
-            list_version.append("NeuNorm: unknown")
-        else:
-            list_version.append(f"NeuNorm: {NeuNorm.__version__}")
+            list_version.append(f"neunorm: {neunorm.__version__}")
 
         try:
             import qtpy

--- a/src/ibeatles/core/io/tiff.py
+++ b/src/ibeatles/core/io/tiff.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""Float32 TIFF writing for analysis exports.
+
+This is the on-disk format every iBeatles export site produced through
+NeuNorm 1.x (PIL ``Image.fromarray`` on float32 frames): plain
+single-page TIFFs that step3's folder re-import and downstream tools
+read back. Keep the writer and dtype stable unless those readers move
+with it.
+"""
+
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+from PIL import Image
+
+
+def write_float32_tiff(data: np.ndarray, file_path: Union[str, Path]) -> None:
+    """Write a 2D array as a single-page float32 TIFF.
+
+    Parameters
+    ----------
+    data : np.ndarray
+        2D image to write. Cast to float32, matching the NeuNorm 1.x
+        writer this replaces.
+    file_path : str or Path
+        Full output path, extension included.
+    """
+    frame = np.asarray(data, dtype=np.float32)
+    if frame.ndim != 2:
+        raise ValueError(f"Expected a 2D image, got shape {frame.shape}")
+    Image.fromarray(frame).save(str(file_path))

--- a/src/ibeatles/core/processing/normalization.py
+++ b/src/ibeatles/core/processing/normalization.py
@@ -1,17 +1,43 @@
 #!/usr/bin/env python
-"""Normalization functions for the TOF imaging data."""
+"""Normalization functions for the TOF imaging data.
+
+NeuNorm 2.0 port (route (a), issue #412): the transmission division runs
+through ``neunorm.processing.normalizer.normalize_transmission`` on scipp
+DataArrays. The 1.x behaviors that 2.0 dropped are bridged locally and
+pinned by tests/unit/ibeatles/core/processing/test_normalization_contract.py:
+
+- in-memory stacks (2.0 loaders are path-based), float32 working dtype
+- pooled multi-ROI background ("air") correction in the 1.x
+  ratio-of-means form, with INCLUSIVE extents — ROI (x0, y0, w, h)
+  covers (w+1) x (h+1) pixels
+- per-frame 1:1 OB pairing when stack counts match, nanmedian(OB)
+  fallback when they don't
+- zero-OB pixels (NaN/inf after division) zeroed in the output; the
+  sample-only path does NOT zero, matching 1.x
+- per-frame ``normalized_image_NNNN.tif`` export (1-based), the on-disk
+  layout the GUI's step3 folder re-import depends on
+
+No variances are attached to the DataArrays: iBeatles stacks may be
+pre-smoothed (moving average) or contain negative pixels, so Poisson
+(counts == variance) statistics would be wrong.
+"""
 
 import logging
 import shutil
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
-from NeuNorm.normalization import Normalization as NeuNormNormalization
-from NeuNorm.roi import ROI
+import scipp as sc
+from neunorm.processing.normalizer import normalize_transmission
 
 from ibeatles.core.config import IBeatlesUserConfig
+from ibeatles.core.io.tiff import write_float32_tiff
 from ibeatles.core.processing.moving_average import moving_average
+
+# (x0, y0, width, height) with 1.x inclusive extents: the region spans
+# columns x0..x0+width and rows y0..y0+height, boundaries included.
+BackgroundROI = Tuple[int, int, int, int]
 
 
 def normalize_data(
@@ -44,34 +70,24 @@ def normalize_data(
     """
     logging.info("Starting normalization process")
 
-    # Create NeuNorm object
-    o_norm = NeuNormNormalization()
-    o_norm.load(data=sample_data)
-    if ob_data is not None:
-        o_norm.load(data=ob_data, data_type="ob")
+    sample_stack = np.asarray(sample_data, dtype=np.float32)
+    ob_stack = np.asarray(ob_data, dtype=np.float32) if ob_data is not None else None
 
     # Apply moving average if configured
     if config.normalization.moving_average.active:
-        logging.info("Applying moving average")
         if config.normalization.processing_order == "Moving average, Normalization":
-            o_norm.data["sample"]["data"] = moving_average(
-                np.array(o_norm.data["sample"]["data"]),  # NeuNorm is return a list of arrays
-                config.normalization.moving_average,
-            )
-            if ob_data is not None:
-                o_norm.data["ob"]["data"] = moving_average(
-                    np.array(o_norm.data["ob"]["data"]),
-                    config.normalization.moving_average,
-                )
+            logging.info("Applying moving average")
+            sample_stack = moving_average(sample_stack, config.normalization.moving_average)
+            if ob_stack is not None:
+                ob_stack = moving_average(ob_stack, config.normalization.moving_average)
 
     # Perform normalization
     logging.info("Performing normalization")
-    background_roi = _get_background_roi(config)
-
-    if ob_data is None:
-        o_norm.normalization(roi=background_roi, use_only_sample=True)
-    else:
-        o_norm.normalization(roi=background_roi if background_roi else None)
+    normalized = normalize_stacks(
+        sample_stack,
+        ob_stack=ob_stack,
+        background_rois=_get_background_rois(config),
+    )
 
     # Apply moving average after normalization if configured
     if (
@@ -79,29 +95,166 @@ def normalize_data(
         and config.normalization.processing_order == "Normalization, Moving Average"
     ):
         logging.info("Applying moving average after normalization")
-        normalized_data = moving_average(
-            np.array(o_norm.get_normalized_data()),
-            config.normalization.moving_average,
-        )
-        # manual replace the normalized data
-        o_norm.data["normalized"] = normalized_data
+        normalized = moving_average(np.array(normalized), config.normalization.moving_average)
 
     # Export normalized data
     full_output_folder = _create_output_folder(output_folder, config)
-    o_norm.export(folder=full_output_folder)
+    export_normalized_stack(normalized, full_output_folder)
 
     # Move time spectra file
     _copy_time_spectra(time_spectra, full_output_folder)
 
-    return o_norm.get_normalized_data(), full_output_folder
+    return normalized, full_output_folder
 
 
-def _get_background_roi(config: IBeatlesUserConfig) -> Optional[List[ROI]]:
-    """Extract background ROI from configuration."""
+def normalize_stacks(
+    sample_stack: np.ndarray,
+    ob_stack: Optional[np.ndarray] = None,
+    background_rois: Optional[Sequence[BackgroundROI]] = None,
+) -> np.ndarray:
+    """Normalize an in-memory sample stack, with 1.x NeuNorm semantics.
+
+    This is the single math path shared by the headless pipeline
+    (``normalize_data``) and the GUI (step2). Inputs are cast to float32
+    (the 1.x working dtype), the division runs through NeuNorm 2.0 on
+    float64 scipp DataArrays, and the result is cast back to float32.
+
+    Parameters
+    ----------
+    sample_stack : np.ndarray
+        Sample images, shape (n_frames, height, width).
+    ob_stack : np.ndarray, optional
+        Open beam images, shape (n_ob, height, width). Frame shape must
+        match the sample. When n_ob != n_frames, the nanmedian of the
+        (ROI-corrected) OB stack is used as a single open beam.
+    background_rois : sequence of (x0, y0, width, height), optional
+        Background regions with inclusive 1.x extents. With an OB, each
+        sample and OB frame is divided by its own pooled mean over all
+        ROIs before the transmission division. Without an OB, at least
+        one ROI is required and each sample frame is divided by its
+        pooled ROI mean.
+
+    Returns
+    -------
+    np.ndarray
+        float32 stack, shape (n_frames, height, width).
+
+    Raises
+    ------
+    ValueError
+        If no OB and no background ROI is provided, if a ROI does not
+        fit inside the image, or if sample and OB frame shapes differ.
+    """
+    sample_stack = _as_float32_stack(sample_stack)
+    rois = [tuple(int(value) for value in roi) for roi in (background_rois or [])]
+    _validate_rois(rois, frame_shape=sample_stack.shape[1:])
+
+    sample = _make_data_array(sample_stack)
+
+    if ob_stack is None:
+        if not rois:
+            raise ValueError("You need to provide at least 1 background ROI to normalize without open beam data!")
+        corrected = sample / _pooled_roi_means(sample, rois)
+        # 1.x does not zero NaN/inf in the sample-only path
+        return corrected.values.astype(np.float32)
+
+    ob_stack = _as_float32_stack(ob_stack)
+    if ob_stack.shape[1:] != sample_stack.shape[1:]:
+        raise ValueError("Sample and open beam frames do not have the same shape!")
+
+    ob = _make_data_array(ob_stack)
+    if rois:
+        sample = sample / _pooled_roi_means(sample, rois)
+        ob = ob / _pooled_roi_means(ob, rois)
+
+    if ob_stack.shape[0] != sample_stack.shape[0]:
+        # 1.x fallback: collapse the (ROI-corrected) OB stack to its
+        # per-pixel nanmedian and divide every sample frame by it
+        ob = _collapse_to_nanmedian(ob)
+
+    transmission = normalize_transmission(sample, ob)
+
+    # 1.x zeroes the NaN/inf that zero-OB pixels produce
+    normalized = np.nan_to_num(transmission.values, nan=0.0, posinf=0.0, neginf=0.0)
+    return normalized.astype(np.float32)
+
+
+def export_normalized_stack(normalized: np.ndarray, folder: str) -> List[str]:
+    """Export one float32 TIFF per frame, in the 1.x on-disk layout.
+
+    Files are named ``normalized_image_NNNN.tif`` with a 1-based index —
+    the layout step3's folder re-import and the existing tests expect.
+
+    Returns the list of file paths written.
+    """
+    paths = []
+    for index, frame in enumerate(normalized, start=1):
+        path = Path(folder) / f"normalized_image_{index:04d}.tif"
+        write_float32_tiff(frame, path)
+        paths.append(str(path))
+    return paths
+
+
+def _as_float32_stack(data: np.ndarray) -> np.ndarray:
+    """Cast to the 1.x float32 working dtype and promote 2D to a 1-frame stack."""
+    stack = np.asarray(data, dtype=np.float32)
+    if stack.ndim == 2:
+        stack = stack[np.newaxis, :, :]
+    if stack.ndim != 3:
+        raise ValueError(f"Expected a 2D image or 3D stack, got shape {stack.shape}")
+    return stack
+
+
+def _make_data_array(stack: np.ndarray) -> sc.DataArray:
+    """Build a scipp DataArray from an in-memory stack (no variances)."""
+    values = np.ascontiguousarray(stack, dtype=np.float64)
+    _, n_y, n_x = values.shape
+    return sc.DataArray(
+        data=sc.array(dims=["N_image", "y", "x"], values=values, unit=sc.units.counts),
+        coords={
+            "y": sc.arange("y", n_y, unit=None),
+            "x": sc.arange("x", n_x, unit=None),
+        },
+    )
+
+
+def _pooled_roi_means(images: sc.DataArray, rois: Sequence[BackgroundROI]) -> sc.Variable:
+    """Per-frame pooled background mean, in the 1.x form.
+
+    Total counts over ALL ROIs divided by total ROI pixels, per frame,
+    with inclusive extents (hence the +1 on both slice stops).
+    """
+    total_counts = None
+    total_pixels = 0
+    for x0, y0, width, height in rois:
+        region = images["y", y0 : y0 + height + 1]["x", x0 : x0 + width + 1]
+        roi_counts = sc.sum(region.data, dim=["y", "x"])
+        total_counts = roi_counts if total_counts is None else total_counts + roi_counts
+        total_pixels += (height + 1) * (width + 1)
+    return total_counts / total_pixels
+
+
+def _collapse_to_nanmedian(images: sc.DataArray) -> sc.DataArray:
+    """Collapse a stack to its per-pixel nanmedian (the 1.x mismatched-counts OB)."""
+    median = np.nanmedian(images.values, axis=0)
+    return sc.DataArray(
+        data=sc.array(dims=["y", "x"], values=median, unit=images.unit),
+        coords={"y": images.coords["y"], "x": images.coords["x"]},
+    )
+
+
+def _validate_rois(rois: Sequence[BackgroundROI], frame_shape: Tuple[int, int]) -> None:
+    """Reject ROIs that do not fit, with the 1.x inclusive-bounds rule."""
+    n_y, n_x = frame_shape
+    for x0, y0, width, height in rois:
+        if x0 < 0 or y0 < 0 or x0 + width >= n_x or y0 + height >= n_y:
+            raise ValueError("roi does not fit into sample image!")
+
+
+def _get_background_rois(config: IBeatlesUserConfig) -> Optional[List[BackgroundROI]]:
+    """Extract background ROIs from configuration."""
     if config.normalization.sample_background:
-        return [
-            ROI(x0=bg.x0, y0=bg.y0, width=bg.width, height=bg.height) for bg in config.normalization.sample_background
-        ]
+        return [(bg.x0, bg.y0, bg.width, bg.height) for bg in config.normalization.sample_background]
     return None
 
 

--- a/src/ibeatles/step2/normalization.py
+++ b/src/ibeatles/step2/normalization.py
@@ -48,9 +48,13 @@ from ibeatles.utilities.status_message_config import (
 class Normalization:
     def __init__(self, parent=None):
         self.parent = parent
+        # specific failure reason surfaced in the status bar by
+        # run_and_export when a step returns None
+        self._failure_message = None
 
     def run_and_export(self):
         logger.info("Running and exporting normalization:")
+        self._failure_message = None
 
         # ask for output folder location
         sample_folder = self.parent.data_metadata["sample"]["folder"]
@@ -107,7 +111,7 @@ class Normalization:
             logger.info("Normalization failed!")
             show_status_message(
                 parent=self.parent,
-                message="Normalization Failed (check logbook)!",
+                message=self._failure_message or "Normalization Failed (check logbook)!",
                 status=StatusMessageStatus.error,
             )
             return False
@@ -276,6 +280,7 @@ class Normalization:
             list_roi_to_use = o_roi_handler.get_list_of_background_roi_to_use()
         except ValueError:
             logger.info(" Error raised when retrieving the background ROI!")
+            self._failure_message = "Normalization failed: check the background ROI table entries!"
             return None
 
         logger.info(f" Background list of ROI: {list_roi_to_use}")
@@ -297,6 +302,7 @@ class Normalization:
             # e.g. no OB and no background ROI — fail through the status
             # bar instead of letting the exception escape the Qt slot
             logger.info(f" Normalization error: {error}")
+            self._failure_message = f"Normalization failed: {error}"
             return None
 
         show_status_message(

--- a/src/ibeatles/step2/normalization.py
+++ b/src/ibeatles/step2/normalization.py
@@ -1,6 +1,22 @@
 #!/usr/bin/env python
 """
 Normalization
+
+The math runs through ibeatles.core.processing.normalization (the
+NeuNorm 2.0 port shared with the headless CLI); this module keeps the
+GUI plumbing: output-folder dialog, status messages, session bookkeeping
+and the step3 re-import of the exported folder.
+
+Two pre-existing behaviors are preserved on purpose so the port changes
+one variable at a time (both are 2026-06-12 audit findings, fixed in the
+coordinated science-fixes PR, not here):
+
+- the open beam is never smoothed by the moving average (the OB branch
+  in the 1.x-era code was dead);
+- in the "normalization then moving average" order, the moving average
+  runs but cannot affect the exported/normalized output (it only ever
+  smoothed the raw sample buffer, after the normalized data had already
+  been computed).
 """
 
 import copy
@@ -9,11 +25,13 @@ import shutil
 
 import numpy as np
 from loguru import logger
-from NeuNorm.normalization import Normalization as NeuNormNormalization
-from NeuNorm.roi import ROI
 from qtpy.QtWidgets import QFileDialog
 
 from ibeatles import DataType
+from ibeatles.core.processing.normalization import (
+    export_normalized_stack,
+    normalize_stacks,
+)
 from ibeatles.session import ReductionDimension, SessionKeys, SessionSubKeys
 from ibeatles.step2.get import Get
 from ibeatles.step2.reduction_settings_handler import ReductionSettingsHandler
@@ -28,9 +46,6 @@ from ibeatles.utilities.status_message_config import (
 
 
 class Normalization:
-    coeff_array = 1  # ob / sample of ROI selected
-    o_norm = None
-
     def __init__(self, parent=None):
         self.parent = parent
 
@@ -72,18 +87,23 @@ class Normalization:
 
         logger.info(f" full output folder will be: {full_output_folder}")
 
-        o_norm = self.create_o_norm()
+        sample_stack, ob_stack = self.get_input_stacks()
 
         if self.parent.session_dict[SessionKeys.reduction][SessionSubKeys.process_order] == "option1":
             # running moving average before running normalization
-            o_norm = self.running_moving_average(o_norm=copy.deepcopy(o_norm))
-            o_norm = self.running_normalization(o_norm=copy.deepcopy(o_norm))
+            sample_stack = self.running_moving_average(sample_stack=sample_stack)
+            normalized = self.running_normalization(sample_stack=sample_stack, ob_stack=ob_stack)
         else:
             # running normalization then moving average
-            o_norm = self.running_normalization(o_norm=copy.deepcopy(o_norm))
-            o_norm = self.running_moving_average(o_norm=copy.deepcopy(o_norm))
+            normalized = self.running_normalization(sample_stack=sample_stack, ob_stack=ob_stack)
+            # preserved no-op: smoothing in this order never reaches the
+            # normalized output (see module docstring) — run it so the GUI
+            # behaves identically (status messages, failure failing the
+            # run), but the smoothed result is discarded
+            if self.running_moving_average(sample_stack=sample_stack) is None:
+                normalized = None
 
-        if not o_norm:
+        if normalized is None:
             logger.info("Normalization failed!")
             show_status_message(
                 parent=self.parent,
@@ -92,8 +112,8 @@ class Normalization:
             )
             return False
 
-        self.export_normalization(o_norm=o_norm, output_folder=full_output_folder)
-        self.saving_normalization_parameters(o_norm=o_norm, output_folder=full_output_folder)
+        self.export_normalization(normalized=normalized, output_folder=full_output_folder)
+        self.saving_normalization_parameters(normalized=normalized, output_folder=full_output_folder)
         self.moving_time_spectra_to_normalizaton_folder(output_folder=full_output_folder)
 
         # repopulate ui with normalized data
@@ -102,19 +122,20 @@ class Normalization:
 
         return True
 
-    def create_o_norm(self):
-        logger.info("Creating o_norm object (to prepare data normalization!")
+    def get_input_stacks(self):
+        """Pull the sample and OB stacks loaded in the GUI.
 
-        _data = self.parent.data_metadata["sample"]["data"]
-        _ob = self.parent.data_metadata["ob"]["data"]
+        Returns (sample_stack, ob_stack) where ob_stack is None when no
+        open beam was loaded (the 1.x-era check was `_ob.any()`).
+        """
+        logger.info("Collecting sample and OB stacks for normalization")
 
         show_status_message(
             parent=self.parent,
             message="Loading data ...",
             status=StatusMessageStatus.working,
         )
-        o_norm = NeuNormNormalization()
-        o_norm.load(data=_data)
+        sample_stack = np.asarray(self.parent.data_metadata["sample"]["data"])
         show_status_message(
             parent=self.parent,
             message="Loading data ... Done!",
@@ -122,13 +143,15 @@ class Normalization:
             duration_s=5,
         )
 
-        if _ob.any():
+        _ob = self.parent.data_metadata["ob"]["data"]
+        ob_stack = None
+        if _ob is not None and np.asarray(_ob).any():
             show_status_message(
                 parent=self.parent,
                 message="Loading ob data ...",
                 status=StatusMessageStatus.working,
             )
-            o_norm.load(data=_ob, data_type=DataType.ob)
+            ob_stack = np.asarray(_ob)
             show_status_message(
                 parent=self.parent,
                 message="Loading ob data ... Done!",
@@ -136,15 +159,15 @@ class Normalization:
                 duration_s=5,
             )
 
-        return o_norm
+        return sample_stack, ob_stack
 
-    def export_normalization(self, o_norm=None, output_folder=None):
+    def export_normalization(self, normalized=None, output_folder=None):
         show_status_message(
             parent=self.parent,
             message="Exporting normalized files ...",
             status=StatusMessageStatus.working,
         )
-        o_norm.export(folder=output_folder)
+        export_normalized_stack(normalized, output_folder)
         show_status_message(
             parent=self.parent,
             message="Exporting normalized files ... Done!",
@@ -162,22 +185,27 @@ class Normalization:
         logger.info(f"-> full_time_spectra: {full_time_spectra}")
         shutil.copy(full_time_spectra, output_folder)
 
-    def saving_normalization_parameters(self, o_norm=None, output_folder=None):
+    def saving_normalization_parameters(self, normalized=None, output_folder=None):
         logger.info("Internally saving normalization parameters (data, folder, time_spectra)")
-        self.parent.data_metadata[DataType.normalized]["data"] = np.array(o_norm.get_normalized_data())
+        self.parent.data_metadata[DataType.normalized]["data"] = np.asarray(normalized)
         self.parent.data_metadata[DataType.normalized]["folder"] = output_folder
         self.parent.data_metadata[DataType.normalized]["time_spectra"] = copy.deepcopy(
             self.parent.data_metadata[DataType.sample]["time_spectra"]
         )
 
-    def running_moving_average(self, o_norm=None):
-        if o_norm is None:
+    def running_moving_average(self, sample_stack=None):
+        """Smooth the sample stack with the configured kernel.
+
+        The open beam is intentionally NOT smoothed — preserved from the
+        previous implementation (see module docstring).
+        """
+        if sample_stack is None:
             return None
 
         running_moving_average_settings = self.parent.session_dict[SessionKeys.reduction]
         if not running_moving_average_settings["activate"]:
             logger.info("Not running moving average! Option has been turned off")
-            return o_norm
+            return sample_stack
 
         show_status_message(
             parent=self.parent,
@@ -201,15 +229,12 @@ class Normalization:
         if reduction_settings["dimension"] == ReductionDimension.threed:
             kernel.append(lda)
 
-        _data = np.array(o_norm.data[DataType.sample]["data"])  # lambda, x, y
-        _data_transposed = _data.transpose(2, 1, 0)  # x, y, lambda
-
         o_get = Get(parent=self.parent)
         kernel_type = o_get.kernel_type()
 
         logger.info(f"-> kernel dimension: {reduction_settings['dimension']}")
         logger.info(f"-> kernel shape: {np.shape(kernel)}")
-        logger.info(f"-> len(sample): {len(_data_transposed)}")
+        logger.info(f"-> sample stack shape: {np.shape(sample_stack)}")
         logger.info(f"-> kernel: {kernel}")
         logger.info(f"-> kernel type: {kernel_type}")
 
@@ -219,20 +244,17 @@ class Normalization:
             message="Moving average of sample data ...",
             status=StatusMessageStatus.working,
         )
-        sample_data = moving_average(data=_data, kernel=kernel, kernel_type=kernel_type)
+        smoothed = moving_average(data=np.asarray(sample_stack), kernel=kernel, kernel_type=kernel_type)
         logger.info("-> Done running moving average with sample data!")
-        if sample_data is None:
+        if smoothed is None:
             logger.info("Moving average failed!")
             show_status_message(
                 parent=self.parent,
                 message="Running moving average ... Failed",
                 status=StatusMessageStatus.error,
             )
-            return
-        else:
-            sample_data.transpose(2, 1, 0)  # lambda, x, y
+            return None
 
-        o_norm.data[DataType.sample]["data"] = sample_data
         show_status_message(
             parent=self.parent,
             message="Moving average of sample data ... Done!",
@@ -240,47 +262,13 @@ class Normalization:
             duration_s=5,
         )
 
-        _ob = np.array(o_norm.data[DataType.ob]["data"])
-        if _ob is None:
-            show_status_message(
-                parent=self.parent,
-                message="Moving average of ob data ...",
-                status=StatusMessageStatus.ready,
-            )
-            logger.info("-> Starting to run moving average with ob data")
-            ob_data = moving_average(data=_ob, kernel=kernel, kernel_type=kernel_type)
-            logger.info("-> Done running moving average with ob data!")
-            if ob_data:
-                ob_data.transpose(2, 1, 0)  # lambda, x, y
-            else:
-                logger.info("Moving average failed!")
-                show_status_message(
-                    parent=self.parent,
-                    message="Running moving average ... Failed",
-                    status=StatusMessageStatus.error,
-                )
-                return
+        return smoothed
 
-            o_norm.data[DataType.ob]["data"] = ob_data
-
-            show_status_message(
-                parent=self.parent,
-                message="Moving average of ob data ... Done!",
-                status=StatusMessageStatus.ready,
-                duration_s=5,
-            )
-
-        return o_norm
-
-    def running_normalization(self, o_norm=None):
+    def running_normalization(self, sample_stack=None, ob_stack=None):
         logger.info(" running normalization!")
 
-        # if o_norm is None:
-        #     _data = self.parent.data_metadata['sample']['data']
-        #     _ob = self.parent.data_metadata['ob']['data']
-        # else:
-        #     _data = o_norm.data[DataType.sample]['data']
-        #     _ob = o_norm.data[DataType.ob]['data']
+        if sample_stack is None:
+            return None
 
         # check if roi selected or not
         o_roi_handler = Step2RoiHandler(parent=self.parent)
@@ -292,44 +280,24 @@ class Normalization:
 
         logger.info(f" Background list of ROI: {list_roi_to_use}")
 
-        if not o_norm.data["ob"]["data"]:
-            # if just sample data
-            return self.normalization_only_sample_data(o_norm, list_roi_to_use)
-        else:
-            # if ob
-            return self.normalization_sample_and_ob_data(o_norm, list_roi_to_use)
-
-    def normalization_only_sample_data(self, o_norm, list_roi):
-        logger.info(" running normalization with only sample data ...")
-
-        # show_status_message(parent=self.parent,
-        #                     message="Loading data ...",
-        #                     status=StatusMessageStatus.working)
-        # o_norm = NeuNormNormalization()
-        # o_norm.load(data=data)
-        # show_status_message(parent=self.parent,
-        #                     message="Loading data ... Done!",
-        #                     status=StatusMessageStatus.working,
-        #                     duration_s=5)
-
-        list_roi_object = []
-        for _roi in list_roi:
-            o_roi = ROI(
-                x0=int(_roi[0]),
-                y0=int(_roi[1]),
-                width=int(_roi[2]),
-                height=int(_roi[3]),
-            )
-            list_roi_object.append(o_roi)
+        background_rois = [(int(_roi[0]), int(_roi[1]), int(_roi[2]), int(_roi[3])) for _roi in list_roi_to_use]
 
         show_status_message(
             parent=self.parent,
             message="Running normalization ...",
             status=StatusMessageStatus.working,
         )
-        o_norm.normalization(roi=list_roi_object, use_only_sample=True)
-
-        # self.o_norm = o_norm
+        try:
+            normalized = normalize_stacks(
+                sample_stack,
+                ob_stack=ob_stack,
+                background_rois=background_rois,
+            )
+        except ValueError as error:
+            # e.g. no OB and no background ROI — fail through the status
+            # bar instead of letting the exception escape the Qt slot
+            logger.info(f" Normalization error: {error}")
+            return None
 
         show_status_message(
             parent=self.parent,
@@ -338,96 +306,5 @@ class Normalization:
             duration_s=5,
         )
 
-        logger.info(" running normalization with only sample data ... Done!")
-        return o_norm
-
-    def normalization_sample_and_ob_data(self, o_norm, list_roi):
-        logger.info(" running normalization with sample and ob data ...")
-
-        # # sample
-        # show_status_message(parent=self.parent,
-        #                     message="Loading sample data ...",
-        #                     status=StatusMessageStatus.working)
-        # o_norm = NeuNormNormalization()
-        # o_norm.load(data=data)
-        # show_status_message(parent=self.parent,
-        #                     message="Loading sample data ... Done!",
-        #                     status=StatusMessageStatus.working)
-        #
-        # # ob
-        # show_status_message(parent=self.parent,
-        #                     message="Loading ob data ...",
-        #                     status=StatusMessageStatus.working)
-        # o_norm.load(data=ob, data_type=DataType.ob)
-        # show_status_message(parent=self.parent,
-        #                     message="Loading ob data ... Done!",
-        #                     status=StatusMessageStatus.working,
-        #                     duration_s=5)
-
-        list_roi_object = []
-        for _roi in list_roi:
-            o_roi = ROI(
-                x0=int(_roi[0]),
-                y0=int(_roi[1]),
-                width=int(_roi[2]),
-                height=int(_roi[3]),
-            )
-            list_roi_object.append(o_roi)
-
-        show_status_message(
-            parent=self.parent,
-            message="Running normalization ...",
-            status=StatusMessageStatus.working,
-        )
-        if list_roi_object:
-            o_norm.normalization(roi=list_roi_object)
-        else:
-            o_norm.normalization()
-
-        # self.o_norm = o_norm
-        #
-        # show_status_message(parent=self.parent,
-        #                     message="Running normalization ... Done!",
-        #                     status=StatusMessageStatus.working,
-        #                     duration_s=5)
-        #
-        # show_status_message(parent=self.parent,
-        #                     message="Exporting normalized files ...",
-        #                     status=StatusMessageStatus.working)
-        # o_norm.export(folder=output_folder)
-        # show_status_message(parent=self.parent,
-        #                     message="Exporting normalized files ... Done!",
-        #                     status=StatusMessageStatus.working,
-        #                     duration_s=5)
-
-        logger.info(" running normalization with sample and ob data ... Done!")
-        return o_norm
-
-    # def can_we_use_buffered_data(self, kernel_dimension=None, kernel_size=None, kernel_type=None):
-    #     if self.parent.moving_average_config is None:
-    #         return False
-    #
-    #     buffered_kernel_dimension = self.parent.moving_average_config.get('kernel_dimension', None)
-    #     if buffered_kernel_dimension is None:
-    #         return False
-    #     if not (kernel_dimension == buffered_kernel_dimension):
-    #         return False
-    #
-    #     buffered_kernel_size = self.parent.moving_average_config.get('kernel_size', None)
-    #     if buffered_kernel_size is None:
-    #         return False
-    #     if not (buffered_kernel_size['x'] == kernel_size['x']):
-    #         return False
-    #     if not (buffered_kernel_size['y'] == kernel_size['y']):
-    #         return False
-    #     if kernel_dimension == '3d':
-    #         if not (buffered_kernel_size['lambda'] == kernel_size['lambda']):
-    #             return False
-    #
-    #     buffered_kernel_type = self.parent.moving_average_config.get('kernel_type', None)
-    #     if buffered_kernel_type is None:
-    #         return False
-    #     if not (buffered_kernel_type == kernel_type):
-    #         return False
-    #
-    #     return True
+        logger.info(" running normalization ... Done!")
+        return normalized

--- a/src/ibeatles/step6/export.py
+++ b/src/ibeatles/step6/export.py
@@ -7,10 +7,10 @@ import logging
 import os
 
 import h5py
-from NeuNorm.normalization import Normalization
 from qtpy.QtWidgets import QFileDialog
 
 from ibeatles import DataType, FileType
+from ibeatles.core.io.tiff import write_float32_tiff
 from ibeatles.fitting import FittingKeys
 from ibeatles.session import SessionKeys, SessionSubKeys
 from ibeatles.step6 import ParametersToDisplay
@@ -38,6 +38,12 @@ class Export:
         base_file_name = os.path.basename(normalized_folder) + "_" + parameters + f".{ext}"
         return base_file_name
 
+    @staticmethod
+    def _tiff_output_path(output_folder, file_name):
+        # NeuNorm 1.x rewrote the extension to ".tif" on export regardless
+        # of the base name's ".tiff" — keep the on-disk names identical
+        return os.path.join(output_folder, os.path.splitext(file_name)[0] + ".tif")
+
     def select_output_folder(self):
         output_folder = str(
             QFileDialog.getExistingDirectory(self.parent, "Select where to export ...", self.working_dir)
@@ -62,40 +68,25 @@ class Export:
 
             if d_spacing_image:
                 d_spacing_file_name = Export._make_image_base_name(self.working_dir)
-                full_d_output_file_name = os.path.join(output_folder, d_spacing_file_name)
-                d_array = o_get.d_array()
-
-                o_norm = Normalization()
-                o_norm.load(data=d_array, notebook=False)
-                o_norm.data["sample"]["file_name"][0] = d_spacing_file_name
-                o_norm.export(data_type="sample", folder=output_folder)
+                full_d_output_file_name = Export._tiff_output_path(output_folder, d_spacing_file_name)
+                write_float32_tiff(o_get.d_array(), full_d_output_file_name)
                 logging.info(f"Export d_spacing: {full_d_output_file_name}")
 
             if strain_mapping_image:
                 strain_mapping_file_name = Export._make_image_base_name(
                     self.working_dir, parameters=ParametersToDisplay.strain_mapping
                 )
-                full_strain_output_file_name = os.path.join(output_folder, strain_mapping_file_name)
-                strain_mapping_array = o_get.strain_mapping()
-
-                o_norm = Normalization()
-                o_norm.load(data=strain_mapping_array, notebook=False)
-                o_norm.data["sample"]["file_name"][0] = strain_mapping_file_name
-                o_norm.export(data_type="sample", folder=output_folder)
+                full_strain_output_file_name = Export._tiff_output_path(output_folder, strain_mapping_file_name)
+                write_float32_tiff(o_get.strain_mapping(), full_strain_output_file_name)
                 logging.info(f"Export strain mapping: {full_strain_output_file_name}")
 
             if integrated_image:
                 integrated_image_file_name = Export._make_image_base_name(
                     self.working_dir, parameters=ParametersToDisplay.integrated_image
                 )
-                full_image_output_file_name = os.path.join(output_folder, integrated_image_file_name)
-                integrated_image = o_get.integrated_image()
-
-                o_norm = Normalization()
-                o_norm.load(data=integrated_image, notebook=False)
-                o_norm.data["sample"]["file_name"][0] = integrated_image_file_name
-                o_norm.export(data_type="sample", folder=output_folder)
-                logging.info(f"Export strain mapping: {full_image_output_file_name}")
+                full_image_output_file_name = Export._tiff_output_path(output_folder, integrated_image_file_name)
+                write_float32_tiff(o_get.integrated_image(), full_image_output_file_name)
+                logging.info(f"Export integrated image: {full_image_output_file_name}")
 
     def table(self, file_type=FileType.ascii, output_folder=None):
         if output_folder is None:

--- a/src/ibeatles/tools/tof_bin/export_images.py
+++ b/src/ibeatles/tools/tof_bin/export_images.py
@@ -8,11 +8,10 @@ import logging
 import os
 from pathlib import Path
 
-import inflect
 import numpy as np
-from NeuNorm.normalization import Normalization
 from qtpy.QtWidgets import QFileDialog
 
+from ibeatles.core.io.tiff import write_float32_tiff
 from ibeatles.session import SessionKeys, SessionSubKeys
 from ibeatles.tools.tof_bin.statistics import Statistics
 from ibeatles.tools.utilities import TimeSpectraKeys
@@ -98,10 +97,8 @@ class ExportImages:
             _data_dict = o_statistics.extract_data_for_this_bin(list_runs=_bin)
             full_image = _data_dict["full_image"]
             counts_array.append(int(np.sum(full_image)))
-            o_norm = Normalization()
-            o_norm.load(data=full_image)
-            o_norm.data["sample"]["file_name"][0] = os.path.basename(output_file_name)
-            o_norm.export(folder=_folder, data_type="sample", file_type="tiff")
+            base_name = os.path.splitext(os.path.basename(output_file_name))[0]
+            write_float32_tiff(full_image, os.path.join(_folder, base_name + ".tiff"))
 
             self.parent.eventProgress.setValue(_index + 1)
 
@@ -119,8 +116,8 @@ class ExportImages:
         )
 
         self.parent.eventProgress.setVisible(False)
-        p = inflect.engine()
-        self.logger.info(f"Done exporting {number_of_file_created} " + p.plural("file", number_of_file_created) + "!")
+        plural = "file" if number_of_file_created == 1 else "files"
+        self.logger.info(f"Done exporting {number_of_file_created} {plural}!")
         show_status_message(
             parent=self.parent,
             message=f"ExportImages to folder {_folder} ... Done!",

--- a/src/ibeatles/tools/tof_bin/tof_bin_export_launcher.py
+++ b/src/ibeatles/tools/tof_bin/tof_bin_export_launcher.py
@@ -9,11 +9,11 @@ import os
 import warnings
 
 import numpy as np
-from NeuNorm.normalization import Normalization
 from qtpy.QtWidgets import QApplication, QDialog, QFileDialog
 
 from ibeatles import DataType, load_ui
 from ibeatles.core.detector import compute_counts_with_uncertainty
+from ibeatles.core.io.tiff import write_float32_tiff
 from ibeatles.session import SessionSubKeys
 from ibeatles.tools.tof_bin.event_handler import EventHandler as TofBinEventHandler
 from ibeatles.tools.tof_bin.utilities.get import Get
@@ -116,10 +116,8 @@ class TofBinExportLauncher(QDialog):
 
             # full image export
             counts_array.append(int(np.sum(_image)))
-            o_norm = Normalization()
-            o_norm.load(data=_image)
-            o_norm.data["sample"]["file_name"][0] = os.path.basename(output_file_name)
-            o_norm.export(folder=output_folder, data_type="sample", file_type="tiff")
+            base_name = os.path.splitext(os.path.basename(output_file_name))[0]
+            write_float32_tiff(_image, os.path.join(output_folder, base_name + ".tiff"))
             logging.info(f" -> exported {output_file_name}")
 
             file_info_dict[short_file_name] = {

--- a/src/ibeatles/tools/tof_combine/export/export_images.py
+++ b/src/ibeatles/tools/tof_combine/export/export_images.py
@@ -7,9 +7,9 @@ import logging
 import os
 import shutil
 
-from NeuNorm.normalization import Normalization
 from qtpy.QtWidgets import QFileDialog
 
+from ibeatles.core.io.tiff import write_float32_tiff
 from ibeatles.tools.tof_combine.utilities.get import Get
 from ibeatles.tools.utilities import TimeSpectraKeys
 from ibeatles.utilities.file_handler import FileHandler
@@ -55,10 +55,7 @@ class ExportImages:
         combine_arrays = self.parent.combine_data
         for _index, _array in enumerate(combine_arrays):
             short_file_name = f"image_{_index:04d}"
-            o_norm = Normalization()
-            o_norm.load(data=_array)
-            o_norm.data["sample"]["file_name"][0] = short_file_name
-            o_norm.export(folder=output_folder, data_type="sample", file_type="tiff")
+            write_float32_tiff(_array, os.path.join(output_folder, short_file_name + ".tiff"))
             self.parent.eventProgress.setValue(_index + 1)
 
         # export time spectra file

--- a/tests/unit/ibeatles/core/io/test_tiff.py
+++ b/tests/unit/ibeatles/core/io/test_tiff.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""Unit tests for the float32 TIFF writer (the 1.x-compatible export format)."""
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from ibeatles.core.io.tiff import write_float32_tiff
+
+
+def test_round_trip_preserves_float32_pixels(tmp_path):
+    frame = np.linspace(0.0, 1.0, 64, dtype=np.float64).reshape(8, 8)
+    path = tmp_path / "frame.tif"
+
+    write_float32_tiff(frame, path)
+
+    with Image.open(str(path)) as img:
+        on_disk = np.array(img)
+    assert on_disk.dtype == np.float32
+    np.testing.assert_array_equal(on_disk, frame.astype(np.float32))
+
+
+def test_rejects_non_2d_input(tmp_path):
+    with pytest.raises(ValueError, match="2D"):
+        write_float32_tiff(np.ones((2, 4, 4)), tmp_path / "bad.tif")

--- a/tests/unit/ibeatles/core/processing/test_normalize_stacks.py
+++ b/tests/unit/ibeatles/core/processing/test_normalize_stacks.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+"""Unit tests for the normalize_stacks/export helpers added by the
+NeuNorm 2.0 port. The 1.x numeric semantics themselves are pinned by
+test_normalization_contract.py; these cover the public-surface edges."""
+
+import numpy as np
+import pytest
+
+from ibeatles.core.processing.normalization import (
+    export_normalized_stack,
+    normalize_stacks,
+)
+
+FRAMES, HEIGHT, WIDTH = 3, 8, 8
+
+
+class TestInputHandling:
+    def test_2d_input_promoted_to_single_frame(self):
+        sample = np.full((HEIGHT, WIDTH), 6.0)
+        ob = np.full((HEIGHT, WIDTH), 3.0)
+
+        normalized = normalize_stacks(sample, ob_stack=ob)
+
+        assert normalized.shape == (1, HEIGHT, WIDTH)
+        np.testing.assert_allclose(normalized, 2.0, rtol=1e-6)
+
+    def test_mismatched_frame_shapes_raise(self):
+        sample = np.ones((FRAMES, HEIGHT, WIDTH))
+        ob = np.ones((FRAMES, HEIGHT, WIDTH + 2))
+
+        with pytest.raises(ValueError, match="same shape"):
+            normalize_stacks(sample, ob_stack=ob)
+
+    def test_output_is_float32(self):
+        sample = np.ones((FRAMES, HEIGHT, WIDTH), dtype=np.float64)
+        ob = np.ones((FRAMES, HEIGHT, WIDTH), dtype=np.float64)
+
+        assert normalize_stacks(sample, ob_stack=ob).dtype == np.float32
+
+
+class TestRoiBounds:
+    """1.x inclusive-bounds rule: ROI (x0, y0, w, h) spans x0..x0+w, so a
+    width-(N-1) ROI fills an N-wide image and width-N falls outside it."""
+
+    def test_widest_fitting_roi_accepted(self):
+        sample = np.ones((FRAMES, HEIGHT, WIDTH))
+
+        normalized = normalize_stacks(sample, background_rois=[(0, 0, WIDTH - 1, HEIGHT - 1)])
+
+        np.testing.assert_allclose(normalized, 1.0, rtol=1e-6)
+
+    def test_roi_exceeding_image_raises(self):
+        sample = np.ones((FRAMES, HEIGHT, WIDTH))
+
+        with pytest.raises(ValueError, match="does not fit"):
+            normalize_stacks(sample, background_rois=[(0, 0, WIDTH, HEIGHT - 1)])
+
+    def test_negative_origin_raises(self):
+        sample = np.ones((FRAMES, HEIGHT, WIDTH))
+
+        with pytest.raises(ValueError, match="does not fit"):
+            normalize_stacks(sample, background_rois=[(-1, 0, 2, 2)])
+
+
+class TestSampleOnlyEdge:
+    def test_sample_only_path_does_not_zero_inf(self):
+        """1.x never zeroed NaN/inf in use_only_sample mode — a zero-count
+        background ROI propagates inf instead of being masked. Pinned so
+        the (deliberate) asymmetry with the OB path is not 'fixed' silently."""
+        sample = np.ones((FRAMES, HEIGHT, WIDTH))
+        sample[:, :3, :3] = 0.0  # ROI mean -> 0 -> division by zero
+
+        normalized = normalize_stacks(sample, background_rois=[(0, 0, 2, 2)])
+
+        assert np.isinf(normalized).any()
+
+
+class TestExportNaming:
+    def test_one_based_zero_padded_layout(self, tmp_path):
+        stack = np.ones((FRAMES, HEIGHT, WIDTH), dtype=np.float32)
+
+        paths = export_normalized_stack(stack, str(tmp_path))
+
+        assert [p.split("/")[-1] for p in paths] == [
+            "normalized_image_0001.tif",
+            "normalized_image_0002.tif",
+            "normalized_image_0003.tif",
+        ]


### PR DESCRIPTION
# ⚠️ DO NOT MERGE — awaiting CIS hands-on testing

This is a **load-bearing PR** under the flagship rule: it swaps the normalization engine that produces every downstream number (binning → fitting → strain). CI green and review are **not sufficient**. Jean (CIS) must complete the side-by-side protocol below on real data first.

## What

The route-(a) NeuNorm 2.0 port decided 2026-06-12 (#412):

- **`core/processing/normalization.py`** — the transmission division now runs through `neunorm.processing.normalizer.normalize_transmission` on scipp DataArrays. The 1.x behaviors that 2.0 dropped are bridged locally in a new single math path, `normalize_stacks()`:
  - in-memory stacks (2.0 loaders are path-based); float32 working dtype
  - pooled multi-ROI background correction in the 1.x ratio-of-means form, with the **inclusive** ROI extents (a width-w ROI covers w+1 pixels)
  - per-frame 1:1 OB pairing when stack counts match; `nanmedian(OB)` fallback when they don't
  - zero-OB pixels (NaN/inf) zeroed; the sample-only path does **not** zero (1.x asymmetry, now pinned by a test)
  - per-frame `normalized_image_NNNN.tif` float32 export — the on-disk layout step3's folder re-import depends on
  - no variances attached: iBeatles stacks may be pre-smoothed or contain negative pixels, so Poisson statistics would be wrong
- **step2 GUI** — the parallel NeuNorm implementation is gone; the GUI now delegates to `normalize_stacks()`, keeping its dialogs, status messages, session bookkeeping, and the step3 auto re-import.
- **Writer-only sites** (step6 image exports, tof_bin ×2, tof_combine) — NeuNorm replaced by `core/io/tiff.write_float32_tiff` (PIL, the same writer 1.x used). On-disk names are preserved exactly, including 1.x's quirk of rewriting step6's `.tiff` base names to `.tif`.
- **About box** — reports `neunorm: 2.0.0`; the duplicated version blocks are deduped.
- **Packaging** — `neunorm>=2.0.0,<3` + `scipp` in pyproject/pixi/environment.yml; the conda recipe's 1.x pip-vendoring workaround is replaced by a real `neunorm` run requirement (2.0 publishes a clean conda package to neutronimaging — the recipe's own TODO comment). Lockfile resolved: neunorm 2.0.0 (PyPI wheel), scipp 26.3.1 (conda-forge).

## Numeric gate

- The 9 value-pinning contract tests from #415 pass **unmodified** — they were written against pinned NeuNorm 1.6.12 with formula-based expectations and are the port's acceptance gate.
- Full suite: **223 passed**, pre-commit clean.
- Expected agreement with 1.x on real data: **float32 precision (`rtol ≤ 1e-5`), not bit-identity** — 1.x accumulated sums in float32; the port computes in float64 and rounds once at the end. Differences should be last-ulp only.

## Behavior preserved vs changed

Preserved **on purpose** so this PR changes one variable at a time (both are audit findings; fixes are in the coordinated science-fixes PR, not here):
1. The GUI moving average never smooths the OB (the 1.x-era OB branch was dead code).
2. In the "normalization then moving average" order the moving average still runs (status messages, failure fails the run) but cannot affect the normalized output — exactly as today.

Changed (UX/logging only, no numbers):
- no-OB + no-background-ROI now fails through the status bar instead of letting `ValueError` escape the Qt slot (PyQt5 aborts on that);
- a moving-average failure in the "average first" order now fails gracefully instead of crashing on `None`;
- step6's integrated-image log line says "integrated image" (was a copy-paste "strain mapping") and logs the real `.tif` path;
- `import inflect` removed from tof_bin/export_images.py — the package was never declared in any manifest nor present in any lockfile, so the module-level import was a latent crash; it only pluralized one log word.

## Testing protocol for CIS (Jean)

Setup: current release (1.x engine) vs this branch, same machine, same data. Suggested comparison: `np.testing.assert_allclose(old, new, rtol=1e-5)` over the exported TIFFs, plus end-to-end strain/d-spacing outputs. Run with **moving average OFF** for the numeric comparisons (the smoothing axis itself is a known bug being fixed separately; with MA on, compare only "runs and exports without errors").

| # | Scenario | What to compare |
|---|----------|-----------------|
| 1 | Sample + OB, equal frame counts, no background ROI | exported `normalized_*.tif` values; step3 auto-import looks right |
| 2 | Sample + OB, equal counts, 2+ background ROIs | exported values (exercises pooled multi-ROI + inclusive extents) |
| 3 | Sample + OB with **different** frame counts | exported values (exercises the nanmedian(OB) fallback) |
| 4 | Sample only + background ROI(s) | exported values |
| 5 | Sample only, **no** ROI | error message in the status bar; app does not crash |
| 6 | Dataset with zero-count OB pixels (or synthetic) | those pixels are exactly 0 in the output |
| 7 | CLI pipeline (`ibeatles --no-gui` with a config) end-to-end | normalized TIFFs + fitting/strain outputs vs current release |
| 8 | step6 exports (d-spacing, strain map, integrated) | identical file names; pixel values bit-identical (writer swap only) |
| 9 | tof_bin and tof_combine exports | identical names/values; metadata.json + Spectra txt unchanged |
| 10 | About box | shows `neunorm: 2.0.0`, single entry per library |

Acceptance: scenarios 1–7 agree within float32 precision; 8–9 bit-identical; 5 fails loud-but-graceful; no GUI flow regressions.

## Deferred (next PR, also CIS-tested)

Science fixes that change published numbers, kept out of the engine swap deliberately: moving-average axis (smooths wavelength/TOF instead of spatial), the "Normalization, Moving Average" order no-op, step6 strain-error formula, spectra empty-bin alignment, shipped config.json `debugging: true`.

Also queued for that batch (surfaced by Copilot review, pre-existing in the current release): tof_bin's `metadata.json` and logs record `image_NNNN.tif` names while the files land as `.tiff` — a 1.x `export(file_type="tiff")` extension-rewrite quirk this PR preserves byte-for-byte on purpose.

Closes #412 (with the science-fixes PR completing the epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
