### PR TITLE
refactor: delegate pooled background-ROI normalization to NeuNorm >= 2.2.2

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -62,6 +62,24 @@ ignore:
   - vulnerability: CVE-2026-9669 # HIGH: bz2.BZ2Decompressor OOB write on reuse; fixed in 3.13.14+, no 3.12 backport
     package:
       name: python
+  # 2026-07-02 grype-DB batch: all fixed in 3.13.14+ / 3.14.5rc1+ / 3.15
+  # betas only; CPython 3.12.13 is still the newest conda-forge 3.12 build,
+  # so no packaged fix is installable in the 3.12 line.
+  - vulnerability: CVE-2026-1502 # medium
+    package:
+      name: python
+  - vulnerability: CVE-2026-3298 # high
+    package:
+      name: python
+  - vulnerability: CVE-2026-4786 # high
+    package:
+      name: python
+  - vulnerability: CVE-2026-6100 # high
+    package:
+      name: python
+  - vulnerability: CVE-2026-12003 # medium; fixed in 3.15.0b3 only
+    package:
+      name: python
 
   # Qt 5.15 open-source receives no upstream fixes (patches land in Qt 6
   # only), so every qt 5.15.x advisory counts as "fixable" while no fix is

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - astropy
   - lmfit
   # NeuNorm 2.0 port landed with #412 — scipp comes with it
-  - neunorm>=2.0.0,<3
+  - neunorm>=2.2.2,<3
   - scipp
   # storage
   - h5py

--- a/pixi.lock
+++ b/pixi.lock
@@ -444,10 +444,10 @@ environments:
       - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/09/fe/f61e7129e9e689d9e40bbf8a36fb90f04eceb477f4617c02c6a18463e81f/configparser-7.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/29/47/23b3ea13967dd512f3c0da27257df5e18e9ecdfeae4d14e1f3900ea2ce20/neunorm-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/1b/86cddfc25214090fa0c07f0c1716bcd201c40dbfaf79bc9a184a238206d9/neutronbraggedge-2.0.6-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/61/d4/d418e9bb010c4cf0df3a90489fbbea2e722763fa343028745dfe0df9cdbe/neunorm-2.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/47/72fd8b2e60a957c9dc1c9a6171a9b016a45120e7f258851f16b940c731a5/scitiff-26.1.0-py3-none-any.whl
@@ -834,10 +834,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/09/fe/f61e7129e9e689d9e40bbf8a36fb90f04eceb477f4617c02c6a18463e81f/configparser-7.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/29/47/23b3ea13967dd512f3c0da27257df5e18e9ecdfeae4d14e1f3900ea2ce20/neunorm-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/1b/86cddfc25214090fa0c07f0c1716bcd201c40dbfaf79bc9a184a238206d9/neutronbraggedge-2.0.6-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/61/d4/d418e9bb010c4cf0df3a90489fbbea2e722763fa343028745dfe0df9cdbe/neunorm-2.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
@@ -1257,8 +1257,8 @@ environments:
       - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/09/fe/f61e7129e9e689d9e40bbf8a36fb90f04eceb477f4617c02c6a18463e81f/configparser-7.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/29/47/23b3ea13967dd512f3c0da27257df5e18e9ecdfeae4d14e1f3900ea2ce20/neunorm-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/1b/86cddfc25214090fa0c07f0c1716bcd201c40dbfaf79bc9a184a238206d9/neutronbraggedge-2.0.6-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/61/d4/d418e9bb010c4cf0df3a90489fbbea2e722763fa343028745dfe0df9cdbe/neunorm-2.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/47/72fd8b2e60a957c9dc1c9a6171a9b016a45120e7f258851f16b940c731a5/scitiff-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a7/dede35a22f31785ef06be5384c3597bce3be086f03ce263c2d08f2c5d5cd/changepy-0.4.0-py3-none-any.whl
@@ -1626,8 +1626,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/09/fe/f61e7129e9e689d9e40bbf8a36fb90f04eceb477f4617c02c6a18463e81f/configparser-7.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/29/47/23b3ea13967dd512f3c0da27257df5e18e9ecdfeae4d14e1f3900ea2ce20/neunorm-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/1b/86cddfc25214090fa0c07f0c1716bcd201c40dbfaf79bc9a184a238206d9/neutronbraggedge-2.0.6-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/61/d4/d418e9bb010c4cf0df3a90489fbbea2e722763fa343028745dfe0df9cdbe/neunorm-2.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/47/72fd8b2e60a957c9dc1c9a6171a9b016a45120e7f258851f16b940c731a5/scitiff-26.1.0-py3-none-any.whl
@@ -2087,8 +2087,8 @@ environments:
       - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/09/fe/f61e7129e9e689d9e40bbf8a36fb90f04eceb477f4617c02c6a18463e81f/configparser-7.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/29/47/23b3ea13967dd512f3c0da27257df5e18e9ecdfeae4d14e1f3900ea2ce20/neunorm-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/1b/86cddfc25214090fa0c07f0c1716bcd201c40dbfaf79bc9a184a238206d9/neutronbraggedge-2.0.6-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/61/d4/d418e9bb010c4cf0df3a90489fbbea2e722763fa343028745dfe0df9cdbe/neunorm-2.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/47/72fd8b2e60a957c9dc1c9a6171a9b016a45120e7f258851f16b940c731a5/scitiff-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a7/dede35a22f31785ef06be5384c3597bce3be086f03ce263c2d08f2c5d5cd/changepy-0.4.0-py3-none-any.whl
@@ -2459,10 +2459,10 @@ environments:
       - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/09/fe/f61e7129e9e689d9e40bbf8a36fb90f04eceb477f4617c02c6a18463e81f/configparser-7.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/29/47/23b3ea13967dd512f3c0da27257df5e18e9ecdfeae4d14e1f3900ea2ce20/neunorm-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/1b/86cddfc25214090fa0c07f0c1716bcd201c40dbfaf79bc9a184a238206d9/neutronbraggedge-2.0.6-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/61/d4/d418e9bb010c4cf0df3a90489fbbea2e722763fa343028745dfe0df9cdbe/neunorm-2.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/47/72fd8b2e60a957c9dc1c9a6171a9b016a45120e7f258851f16b940c731a5/scitiff-26.1.0-py3-none-any.whl
@@ -2784,10 +2784,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/09/fe/f61e7129e9e689d9e40bbf8a36fb90f04eceb477f4617c02c6a18463e81f/configparser-7.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/29/47/23b3ea13967dd512f3c0da27257df5e18e9ecdfeae4d14e1f3900ea2ce20/neunorm-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/1b/86cddfc25214090fa0c07f0c1716bcd201c40dbfaf79bc9a184a238206d9/neutronbraggedge-2.0.6-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/61/d4/d418e9bb010c4cf0df3a90489fbbea2e722763fa343028745dfe0df9cdbe/neunorm-2.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
@@ -3354,7 +3354,7 @@ packages:
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause AND MIT AND EPL-2.0
   purls:
-  - pkg:pypi/backports-zstd?source=compressed-mapping
+  - pkg:pypi/backports-zstd?source=hash-mapping
   size: 239928
   timestamp: 1778594049826
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bottleneck-1.6.0-np2py312hfb8c2c5_3.conda
@@ -8849,7 +8849,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/ipython?source=compressed-mapping
+  - pkg:pypi/ipython?source=hash-mapping
   size: 652893
   timestamp: 1780654403616
 - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
@@ -14291,7 +14291,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/scipy?source=compressed-mapping
+  - pkg:pypi/scipy?source=hash-mapping
   size: 13936510
   timestamp: 1779874824714
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/simdjson-4.6.4-h4ddebb9_0.conda
@@ -14598,7 +14598,7 @@ packages:
   - scipp
   - neutronbraggedge>=2.0.6,<3
   - changepy>=0.4.0,<0.5
-  - neunorm>=2.0.0,<3
+  - neunorm>=2.2.2,<3
   requires_python: '>=3.12,<3.13'
 - pypi: https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
   name: lxml
@@ -14629,30 +14629,6 @@ packages:
   - pytest-enabler>=2.2 ; extra == 'enabler'
   - pytest-mypy ; extra == 'type'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/29/47/23b3ea13967dd512f3c0da27257df5e18e9ecdfeae4d14e1f3900ea2ce20/neunorm-2.0.0-py3-none-any.whl
-  name: neunorm
-  version: 2.0.0
-  sha256: 30e4c5c2549067e92815c6ce456974ea8911c35fe39f2db60d528154b3919bf0
-  requires_dist:
-  - astropy
-  - h5py>=3.0
-  - loguru>=0.7
-  - numpy>=2.0,<3
-  - pillow
-  - pydantic>=2.0
-  - scipp>=25.8.0
-  - scipy>=1.11
-  - scitiff>=26.1
-  - tqdm
-  - myst-parser ; extra == 'docs'
-  - nbsphinx ; extra == 'docs'
-  - sphinx ; extra == 'docs'
-  - sphinx-rtd-theme ; extra == 'docs'
-  - versioningit ; extra == 'docs'
-  - numba>=0.60 ; extra == 'performance'
-  - matplotlib ; extra == 'viz'
-  - plopp>=25.10.0 ; extra == 'viz'
-  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
   name: referencing
   version: 0.37.0
@@ -14680,6 +14656,30 @@ packages:
   - lxml
   - html5lib
   - beautifulsoup4
+- pypi: https://files.pythonhosted.org/packages/61/d4/d418e9bb010c4cf0df3a90489fbbea2e722763fa343028745dfe0df9cdbe/neunorm-2.2.2-py3-none-any.whl
+  name: neunorm
+  version: 2.2.2
+  sha256: e319e65216a912a1262d59dc09bccac3d71b0cd246ce57494d6e7d0e2649f7c8
+  requires_dist:
+  - astropy
+  - h5py>=3.0
+  - loguru>=0.7
+  - numpy>=2.0,<3
+  - pillow
+  - pydantic>=2.0
+  - scipp>=25.8.0
+  - scipy>=1.11
+  - scitiff>=26.1
+  - tqdm
+  - myst-parser ; extra == 'docs'
+  - nbsphinx ; extra == 'docs'
+  - sphinx ; extra == 'docs'
+  - sphinx-rtd-theme ; extra == 'docs'
+  - versioningit ; extra == 'docs'
+  - numba>=0.60 ; extra == 'performance'
+  - matplotlib ; extra == 'viz'
+  - plopp>=25.10.0 ; extra == 'viz'
+  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
   name: jsonschema
   version: 4.26.0

--- a/pixi.lock
+++ b/pixi.lock
@@ -454,7 +454,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/6b/eb86e899a58ac6357891aef7d548451dc46f1ea53e6a51f97a194d14df7d/scitiff-26.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bb/4d/e5aa499ce4e01134fd2182b0348d661a09601d6711f945f9641c71684bfc/neunorm-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a7/dede35a22f31785ef06be5384c3597bce3be086f03ce263c2d08f2c5d5cd/changepy-0.4.0-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
@@ -850,7 +849,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/80/6b/eb86e899a58ac6357891aef7d548451dc46f1ea53e6a51f97a194d14df7d/scitiff-26.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/bb/4d/e5aa499ce4e01134fd2182b0348d661a09601d6711f945f9641c71684bfc/neunorm-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a7/dede35a22f31785ef06be5384c3597bce3be086f03ce263c2d08f2c5d5cd/changepy-0.4.0-py3-none-any.whl
   jupyter:
     channels:
@@ -1270,6 +1268,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/09/fe/f61e7129e9e689d9e40bbf8a36fb90f04eceb477f4617c02c6a18463e81f/configparser-7.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/1b/86cddfc25214090fa0c07f0c1716bcd201c40dbfaf79bc9a184a238206d9/neutronbraggedge-2.0.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/d4/d418e9bb010c4cf0df3a90489fbbea2e722763fa343028745dfe0df9cdbe/neunorm-2.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/6b/eb86e899a58ac6357891aef7d548451dc46f1ea53e6a51f97a194d14df7d/scitiff-26.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a7/dede35a22f31785ef06be5384c3597bce3be086f03ce263c2d08f2c5d5cd/changepy-0.4.0-py3-none-any.whl
       osx-arm64:
@@ -1646,7 +1645,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/80/6b/eb86e899a58ac6357891aef7d548451dc46f1ea53e6a51f97a194d14df7d/scitiff-26.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bb/4d/e5aa499ce4e01134fd2182b0348d661a09601d6711f945f9641c71684bfc/neunorm-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a7/dede35a22f31785ef06be5384c3597bce3be086f03ce263c2d08f2c5d5cd/changepy-0.4.0-py3-none-any.whl
   package:
     channels:
@@ -2107,6 +2105,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/09/fe/f61e7129e9e689d9e40bbf8a36fb90f04eceb477f4617c02c6a18463e81f/configparser-7.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/1b/86cddfc25214090fa0c07f0c1716bcd201c40dbfaf79bc9a184a238206d9/neutronbraggedge-2.0.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/d4/d418e9bb010c4cf0df3a90489fbbea2e722763fa343028745dfe0df9cdbe/neunorm-2.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/6b/eb86e899a58ac6357891aef7d548451dc46f1ea53e6a51f97a194d14df7d/scitiff-26.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a7/dede35a22f31785ef06be5384c3597bce3be086f03ce263c2d08f2c5d5cd/changepy-0.4.0-py3-none-any.whl
   py312:
@@ -2486,7 +2485,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/6b/eb86e899a58ac6357891aef7d548451dc46f1ea53e6a51f97a194d14df7d/scitiff-26.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bb/4d/e5aa499ce4e01134fd2182b0348d661a09601d6711f945f9641c71684bfc/neunorm-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a7/dede35a22f31785ef06be5384c3597bce3be086f03ce263c2d08f2c5d5cd/changepy-0.4.0-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
@@ -2817,7 +2815,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/80/6b/eb86e899a58ac6357891aef7d548451dc46f1ea53e6a51f97a194d14df7d/scitiff-26.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/bb/4d/e5aa499ce4e01134fd2182b0348d661a09601d6711f945f9641c71684bfc/neunorm-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a7/dede35a22f31785ef06be5384c3597bce3be086f03ce263c2d08f2c5d5cd/changepy-0.4.0-py3-none-any.whl
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -3241,7 +3238,7 @@ packages:
   - zstd >=1.5.7,<1.6.0a0
   license: BSD-3-Clause AND MIT AND EPL-2.0
   purls:
-  - pkg:pypi/backports-zstd?source=hash-mapping
+  - pkg:pypi/backports-zstd?source=compressed-mapping
   size: 239928
   timestamp: 1778594049826
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bottleneck-1.6.0-np2py312hfb8c2c5_3.conda
@@ -3716,7 +3713,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/fonttools?source=compressed-mapping
+  - pkg:pypi/fonttools?source=hash-mapping
   run_exports: {}
   size: 3007892
   timestamp: 1778770568019
@@ -8533,7 +8530,7 @@ packages:
   license: LGPL-3.0-only
   license_family: LGPL
   purls:
-  - pkg:pypi/docutils?source=compressed-mapping
+  - pkg:pypi/docutils?source=hash-mapping
   run_exports: {}
   size: 459540
   timestamp: 1779967837277
@@ -8965,7 +8962,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/ipykernel?source=hash-mapping
+  - pkg:pypi/ipykernel?source=compressed-mapping
   run_exports: {}
   size: 137725
   timestamp: 1781101860049
@@ -9037,33 +9034,9 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/ipython?source=hash-mapping
+  - pkg:pypi/ipython?source=compressed-mapping
   size: 651516
   timestamp: 1780068620454
-- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
-  sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
-  md5: fbd58549b374103c1a80577f09a328ef
-  depends:
-  - __unix
-  - decorator >=5.1.0
-  - ipython_pygments_lexers >=1.0.0
-  - jedi >=0.18.2
-  - matplotlib-inline >=0.1.6
-  - prompt-toolkit >=3.0.41,<3.1.0
-  - psutil >=7
-  - pygments >=2.14.0
-  - python >=3.11
-  - stack_data >=0.6.0
-  - traitlets >=5.13.0
-  - typing_extensions >=4.6
-  - pexpect >4.6
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/ipython?source=hash-mapping
-  size: 652893
-  timestamp: 1780654403616
 - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
   sha256: 894682a42a7d659ae12878dbcb274516a7031bbea9104e92f8e88c1f2765a104
   md5: bd80ba060603cc228d9d81c257093119
@@ -9651,7 +9624,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/matplotlib-inline?source=compressed-mapping
+  - pkg:pypi/matplotlib-inline?source=hash-mapping
   run_exports: {}
   size: 15725
   timestamp: 1778264403247
@@ -10681,7 +10654,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/s3fs?source=compressed-mapping
+  - pkg:pypi/s3fs?source=hash-mapping
   run_exports: {}
   size: 36232
   timestamp: 1781621673975
@@ -10923,7 +10896,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/tomlkit?source=hash-mapping
+  - pkg:pypi/tomlkit?source=compressed-mapping
   run_exports: {}
   size: 41169
   timestamp: 1778423744478
@@ -11224,7 +11197,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/virtualenv?source=hash-mapping
+  - pkg:pypi/virtualenv?source=compressed-mapping
   run_exports: {}
   size: 3111990
   timestamp: 1781651033074
@@ -11709,7 +11682,7 @@ packages:
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause AND MIT AND EPL-2.0
   purls:
-  - pkg:pypi/backports-zstd?source=hash-mapping
+  - pkg:pypi/backports-zstd?source=compressed-mapping
   run_exports: {}
   size: 240925
   timestamp: 1781450816363
@@ -11982,7 +11955,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/debugpy?source=hash-mapping
+  - pkg:pypi/debugpy?source=compressed-mapping
   run_exports: {}
   size: 2742535
   timestamp: 1780390215643
@@ -12033,7 +12006,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/fonttools?source=hash-mapping
+  - pkg:pypi/fonttools?source=compressed-mapping
   run_exports: {}
   size: 2904377
   timestamp: 1778771054844
@@ -13916,7 +13889,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/numpy?source=compressed-mapping
+  - pkg:pypi/numpy?source=hash-mapping
   run_exports:
     weak:
     - numpy >=1.25,<3
@@ -14413,7 +14386,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pyzmq?source=hash-mapping
+  - pkg:pypi/pyzmq?source=compressed-mapping
   run_exports: {}
   size: 191432
   timestamp: 1779484184540
@@ -14659,7 +14632,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/scipy?source=hash-mapping
+  - pkg:pypi/scipy?source=compressed-mapping
   size: 13936510
   timestamp: 1779874824714
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/simdjson-4.6.4-h4ddebb9_0.conda
@@ -15204,30 +15177,6 @@ packages:
   name: rpds-py
   version: 2026.6.3
   sha256: 538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf
-  requires_python: '>=3.11'
-- pypi: https://files.pythonhosted.org/packages/bb/4d/e5aa499ce4e01134fd2182b0348d661a09601d6711f945f9641c71684bfc/neunorm-2.2.0-py3-none-any.whl
-  name: neunorm
-  version: 2.2.0
-  sha256: 013bd773efdcb5ca9bbd21444eb48911929f7a3ada2d7dd569b0df48d4f29f3a
-  requires_dist:
-  - astropy
-  - h5py>=3.0
-  - loguru>=0.7
-  - numpy>=2.0,<3
-  - pillow
-  - pydantic>=2.0
-  - scipp>=25.8.0
-  - scipy>=1.11
-  - scitiff>=26.1
-  - tqdm
-  - myst-parser ; extra == 'docs'
-  - nbsphinx ; extra == 'docs'
-  - sphinx ; extra == 'docs'
-  - sphinx-rtd-theme ; extra == 'docs'
-  - versioningit ; extra == 'docs'
-  - numba>=0.60 ; extra == 'performance'
-  - matplotlib ; extra == 'viz'
-  - plopp>=25.10.0 ; extra == 'viz'
   requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/cb/a7/dede35a22f31785ef06be5384c3597bce3be086f03ce263c2d08f2c5d5cd/changepy-0.4.0-py3-none-any.whl
   name: changepy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   # These are the dependencies from our neutron imaging team
   "neutronbraggedge>=2.0.6,<3",
   "changepy>=0.4.0,<0.5",
-  "neunorm>=2.0.0,<3",
+  "neunorm>=2.2.2,<3",
 ]
 
 [project.urls]

--- a/src/ibeatles/core/processing/normalization.py
+++ b/src/ibeatles/core/processing/normalization.py
@@ -3,13 +3,16 @@
 
 NeuNorm 2.0 port (route (a), issue #412): the transmission division runs
 through ``neunorm.processing.normalizer.normalize_transmission`` on scipp
-DataArrays. The 1.x behaviors that 2.0 dropped are bridged locally and
-pinned by tests/unit/ibeatles/core/processing/test_normalization_contract.py:
+DataArrays. The 1.x behaviors that 2.0 dropped are pinned by
+tests/unit/ibeatles/core/processing/test_normalization_contract.py:
 
 - in-memory stacks (2.0 loaders are path-based), float32 working dtype
 - pooled multi-ROI background ("air") correction in the 1.x
   ratio-of-means form, with INCLUSIVE extents — ROI (x0, y0, w, h)
-  covers (w+1) x (h+1) pixels
+  covers (w+1) x (h+1) pixels. As of NeuNorm 2.2.1 this is native:
+  ``background_roi=[ROI(..., inclusive=True), ...]`` (pooled) and
+  ``apply_background_roi`` (sample-only), so no local re-implementation
+  remains (NeuNorm #159/#172).
 - per-frame 1:1 OB pairing when stack counts match, nanmedian(OB)
   fallback when they don't
 - zero-OB pixels (NaN/inf after division) zeroed in the output; the
@@ -29,7 +32,8 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 import scipp as sc
-from neunorm.processing.normalizer import normalize_transmission
+from neunorm.data_models.roi import ROI
+from neunorm.processing.normalizer import apply_background_roi, normalize_transmission
 
 from ibeatles.core.config import IBeatlesUserConfig
 from ibeatles.core.io.tiff import write_float32_tiff
@@ -148,13 +152,17 @@ def normalize_stacks(
     sample_stack = _as_float32_stack(sample_stack)
     rois = [tuple(int(value) for value in roi) for roi in (background_rois or [])]
     _validate_rois(rois, frame_shape=sample_stack.shape[1:])
+    # NeuNorm pools a sequence of ROIs as sum(counts)/sum(pixels) per frame — the 1.x
+    # ratio-of-means form — and inclusive=True keeps the 1.x (w+1) x (h+1) extents.
+    background_roi = [ROI(x0=x0, y0=y0, width=width, height=height, inclusive=True) for x0, y0, width, height in rois]
 
     sample = _make_data_array(sample_stack)
 
     if ob_stack is None:
-        if not rois:
+        if not background_roi:
             raise ValueError("You need to provide at least 1 background ROI to normalize without open beam data!")
-        corrected = sample / _pooled_roi_means(sample, rois)
+        # strict=False: 1.x lets a zero-count ROI propagate inf here (pinned by tests)
+        corrected = apply_background_roi(sample, background_roi, strict=False)
         # 1.x does not zero NaN/inf in the sample-only path
         return corrected.values.astype(np.float32)
 
@@ -163,16 +171,22 @@ def normalize_stacks(
         raise ValueError("Sample and open beam frames do not have the same shape!")
 
     ob = _make_data_array(ob_stack)
-    if rois:
-        sample = sample / _pooled_roi_means(sample, rois)
-        ob = ob / _pooled_roi_means(ob, rois)
 
     if ob_stack.shape[0] != sample_stack.shape[0]:
-        # 1.x fallback: collapse the (ROI-corrected) OB stack to its
-        # per-pixel nanmedian and divide every sample frame by it
+        # 1.x fallback: flux-flatten each stack by its pooled ROI mean, then collapse
+        # the (ROI-corrected) OB to its per-pixel nanmedian and divide every sample
+        # frame by it
+        if background_roi:
+            sample = apply_background_roi(sample, background_roi, strict=False)
+            ob = apply_background_roi(ob, background_roi, strict=False)
         ob = _collapse_to_nanmedian(ob)
-
-    transmission = normalize_transmission(sample, ob)
+        transmission = normalize_transmission(sample, ob)
+    else:
+        # 1:1 pairing: NeuNorm applies the pooled flux proxy on both sides natively,
+        # T = (S / pool(S[B])) / (O / pool(O[B]))
+        transmission = normalize_transmission(
+            sample, ob, background_roi=background_roi or None, background_roi_strict=False
+        )
 
     # 1.x zeroes the NaN/inf that zero-OB pixels produce
     normalized = np.nan_to_num(transmission.values, nan=0.0, posinf=0.0, neginf=0.0)
@@ -216,22 +230,6 @@ def _make_data_array(stack: np.ndarray) -> sc.DataArray:
             "x": sc.arange("x", n_x, unit=None),
         },
     )
-
-
-def _pooled_roi_means(images: sc.DataArray, rois: Sequence[BackgroundROI]) -> sc.Variable:
-    """Per-frame pooled background mean, in the 1.x form.
-
-    Total counts over ALL ROIs divided by total ROI pixels, per frame,
-    with inclusive extents (hence the +1 on both slice stops).
-    """
-    total_counts = None
-    total_pixels = 0
-    for x0, y0, width, height in rois:
-        region = images["y", y0 : y0 + height + 1]["x", x0 : x0 + width + 1]
-        roi_counts = sc.sum(region.data, dim=["y", "x"])
-        total_counts = roi_counts if total_counts is None else total_counts + roi_counts
-        total_pixels += (height + 1) * (width + 1)
-    return total_counts / total_pixels
 
 
 def _collapse_to_nanmedian(images: sc.DataArray) -> sc.DataArray:

--- a/src/ibeatles/core/processing/normalization.py
+++ b/src/ibeatles/core/processing/normalization.py
@@ -12,7 +12,7 @@ tests/unit/ibeatles/core/processing/test_normalization_contract.py:
   covers (w+1) x (h+1) pixels. As of NeuNorm 2.2.1 this is native:
   ``background_roi=[ROI(..., inclusive=True), ...]`` (pooled) and
   ``apply_background_roi`` (sample-only), so no local re-implementation
-  remains (NeuNorm #159/#172).
+  remains (ornlneutronimaging/NeuNorm#159, ornlneutronimaging/NeuNorm#172).
 - per-frame 1:1 OB pairing when stack counts match, nanmedian(OB)
   fallback when they don't
 - zero-OB pixels (NaN/inf after division) zeroed in the output; the


### PR DESCRIPTION
> [!IMPORTANT]
> **Flagship gate: this touches `core/processing/normalization.py`, so per the working rules it requires Jean's hands-on testing (side-by-side runs on real data vs the current release, numeric comparison of exported files) BEFORE merge — CI green + review is not sufficient.** The change is *designed* to be numerically identical (all contract tests pass bit-for-bit), but the rule applies to any normalization-touching change.

## What

Deletes the local `_pooled_roi_means` re-implementation and delegates all background-ROI ("air") normalization math to NeuNorm ≥ 2.2.2, which now natively covers every 1.x behavior it bridged ([NeuNorm#159](https://github.com/ornlneutronimaging/NeuNorm/issues/159), [NeuNorm#172](https://github.com/ornlneutronimaging/NeuNorm/issues/172)):

| 1.x behavior (was local) | NeuNorm 2.2.x |
|---|---|
| pooled multi-ROI ratio-of-means (Σcounts/Σpixels per frame) | `normalize_transmission(..., background_roi=[...])` |
| inclusive extents — `(x0, y0, w, h)` spans `(w+1)×(h+1)` px | `ROI(..., inclusive=True)` |
| sample-only (no open beam) flux flattening | `apply_background_roi(...)` |
| zero-count ROI propagates `inf` (pinned, deliberate) | `strict=False` / `background_roi_strict=False` (v2.2.2) |

`normalize_stacks` now only converts iBeatles' `(x0, y0, w, h)` tuples into inclusive `ROI` objects and delegates. The mismatched-OB nanmedian fallback and the OB-path NaN/inf zeroing stay local (1.x semantics NeuNorm does not model). Pins bumped to `neunorm>=2.2.2,<3` (pyproject, environment.yml, lock refreshed).

## Verification

- **Full suite: 223/223** against the released `neutronimaging::neunorm 2.2.2` from the refreshed lock — including `test_normalization_contract.py` (hand-computed 1.x pooled/inclusive oracles) and the pinned inf-propagation edge in `test_normalize_stacks.py`.
- The NeuNorm side shipped via [NeuNorm#175](https://github.com/ornlneutronimaging/NeuNorm/pull/175) (v2.2.1) + [NeuNorm#177](https://github.com/ornlneutronimaging/NeuNorm/pull/177) (v2.2.2), each through CI + dual-family adversarial review + Copilot.

Closes the duplication that reopened NeuNorm#159; NeuNorm#159/#172 close when this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)