### PR TITLE
fix(ci): ignore 5 more CPython 3.12 advisories blocking the Grype gate

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -62,6 +62,24 @@ ignore:
   - vulnerability: CVE-2026-9669 # HIGH: bz2.BZ2Decompressor OOB write on reuse; fixed in 3.13.14+, no 3.12 backport
     package:
       name: python
+  # Added 2026-07: the Grype vuln DB (v6.1.7) began flagging these CPython 3.12
+  # advisories; all are fixed only in 3.13+/prerelease with no installable 3.12
+  # backport. Remove as conda-forge ships newer 3.12 patch builds.
+  - vulnerability: CVE-2026-1502
+    package:
+      name: python
+  - vulnerability: CVE-2026-3298
+    package:
+      name: python
+  - vulnerability: CVE-2026-4786
+    package:
+      name: python
+  - vulnerability: CVE-2026-6100
+    package:
+      name: python
+  - vulnerability: CVE-2026-12003
+    package:
+      name: python
 
   # Qt 5.15 open-source receives no upstream fixes (patches land in Qt 6
   # only), so every qt 5.15.x advisory counts as "fixable" while no fix is


### PR DESCRIPTION
The 2026-07 Grype vuln DB (v6.1.7) began flagging `CVE-2026-1502`, `-3298`, `-4786`, `-6100`, and `-12003` on `cpython 3.12.13`. All are fixed only in 3.13+/prerelease with no installable 3.12 backport, so the `--fail-on medium --only-fixed` gate now fails on every PR (e.g. #430, #428, #426).

This adds scoped `.grype.yaml` ignores with a reason + revisit condition, matching the existing python block here and the identical fix applied to HyperCTui #196 and timepix #87.

Once this lands on `next`, the held bot PRs (#430 setup-pixi, #428 lockfile, #426 pre-commit) can be updated and merged.

Assisted-With: Claude Opus 4.8 (1M context)