### PR TITLE
ci: SHA-pin all actions/* (supply-chain hardening)

### DIFF
--- a/.github/workflows/dev-conda-publish.yaml
+++ b/.github/workflows/dev-conda-publish.yaml
@@ -16,7 +16,7 @@ jobs:
   dev-conda-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           manifest-path: pyproject.toml
@@ -54,13 +54,13 @@ jobs:
           pixi run -e package build
       - name: upload conda artifact
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: conda-package
           path: conda.recipe/noarch/ibeatles*.tar.bz2
       - name: upload PyPI artifact
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pypi-package
           path: dist/*
@@ -77,7 +77,7 @@ jobs:
       id-token: write
     steps:
       - name: Download PyPI artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pypi-package
           path: dist
@@ -93,16 +93,16 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download conda artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: conda-package
           path: dist/conda
 
       - name: Download PyPI artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pypi-package
           path: dist/pypi

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -31,7 +31,7 @@ jobs:
         # env was previously held back by the packaging stack's caps
         environment: [py312]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           manifest-path: pyproject.toml
@@ -58,7 +58,7 @@ jobs:
       security-events: write # required for upload-sarif
       actions: read # upload-sarif on private repos
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           manifest-path: pyproject.toml

--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -13,7 +13,7 @@ jobs:
   pixi-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:


### PR DESCRIPTION
Pin every GitHub-published `actions/*` (and `github/codeql-action/*`) reference to a full commit SHA with a `# vX.Y.Z` comment, matching the org convention and the already-SHA-pinned third-party actions. **Same versions currently in use — pure format change, no behavior change.** Dependabot maintains SHA pins + comments going forward.

Assisted-With: Claude Opus 4.8 (1M context)